### PR TITLE
updates to remove mct_mod and all other mct related files from share/

### DIFF
--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -796,7 +796,7 @@ contains
 #ifndef NO_MPI2
     use mpi          , only : MPI_COMM_NULL, mpi_comm_size
 #endif
-    use mct_mod      , only : mct_world_init
+    use m_MCTWorld   , only : mct_world_init => init
 
 #ifdef MED_PRESENT
     use med_internalstate_mod , only : med_id


### PR DESCRIPTION
### Description of changes
This simply removes the use of mct_mod from esm.F90 and replaces it with a use directly into mct. 

### Specific notes
This PR is needed once https://github.com/NorESMhub/NorESM_share/pull/2 is merged in.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None 

Are changes expected to change answers? bfb

Any User Interface Changes? No

### Testing performed
Tested an F200 compset in a NorESM configuration.
