### PR TITLE
new dms flux capability in mediator

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -51,6 +51,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config["mask_grid"] = case.get_value("MASK_GRID")
     config["rest_option"] = case.get_value("REST_OPTION")
     config["comp_ocn"] = case.get_value("COMP_OCN")
+    config["COMPSET"] = case.get_value("COMPSET")
 
     atm_grid = case.get_value("ATM_GRID")
     lnd_grid = case.get_value("LND_GRID")

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -65,13 +65,13 @@
     <file>env_run.xml</file>
     <desc>
     integer indicating maximum detail level to profile. This xml
-    variable is used to set the namelist variable
-    timing_detail_limit. This namelist variable is used by perf_mod
+    variable is used to set the config variable
+    timing_detail_limit. This config variable is used by perf_mod
     (in $CIMEROOT/src/share/timing/perf_mod.F90) to turn timers off
     and on depending on calls to the routine t_adj_detailf. If in the
     code a statement appears like t_adj_detailf(+1), then the current
     timer detail level is incremented by 1 and compared to the
-    time_detail_limit obtained from the namelist.  If the limit is
+    time_detail_limit obtained from the config.  If the limit is
     exceeded then the timer is turned off.
     </desc>
   </entry>
@@ -127,22 +127,24 @@
     <file>env_run.xml</file>
     <desc>Activates additional CO2-related fields to be exchanged between components. Possible values are:
 
-    CO2A: sets the driver namelist variable flds_co2a = .true.; this adds
+    CO2A: sets nuopc.runconfig variable flds_co2a = .true.; this adds
     prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
     the atmosphere to the land and ocean.
 
-    CO2B: sets the driver namelist variable flds_co2b = .true.; this adds
+    CO2B: sets nuopc.runconfig variable flds_co2b = .true.; this adds
     prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
     the atmosphere just to the land, and the surface upward flux of CO2 to be
     sent from the land back to the atmosphere
 
-    CO2C: sets the driver namelist variable flds_co2c = .true.; this adds
+    CO2C: sets nuopc.runconfig variable flds_co2c = .true.; this adds
     prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
     the atmosphere to the land and ocean, and the surface upward flux of CO2
     to be sent from the land and the open ocean back to the atmosphere.
 
-    The namelist variables flds_co2a, flds_co2b and flds_co2c are in the
-    namelist group cpl_flds_inparm.
+    DMS: sets nuopc.runconfig variable flds_dms_med = .true.; this adds
+    turns on the computation of DMS flux in the mediator and that flux is passed back to both the
+    ocean (if prognostic) and the atm (if prognostic)
+
     </desc>
   </entry>
 
@@ -169,7 +171,7 @@
       <value compset="_MPAS"       >hour</value>
     </values>
     <desc>Base period associated with NCPL coupling frequency.
-    This xml variable is only used to set the driver namelist variables,
+    This xml variable is only used to set the driver config variables,
     atm_cpl_dt, lnd_cpl_dt, ocn_cpl_dt, ice_cpl_dt, glc_cpl_dt, rof_cpl_dt, wav_cpl_dt, and esp_dt.</desc>
   </entry>
 
@@ -250,7 +252,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>Number of atm coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist atm_cpl_dt, equal to basedt/ATM_NCPL,
+    This is used to set the driver config atm_cpl_dt, equal to basedt/ATM_NCPL,
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
   </entry>
 
@@ -263,7 +265,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>Number of land coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist atm_cpl_dt, equal to basedt/LND_NCPL,
+    This is used to set the driver config atm_cpl_dt, equal to basedt/LND_NCPL,
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
   </entry>
 
@@ -276,7 +278,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>Number of ice coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist ice_cpl_dt, equal to basedt/ICE_NCPL
+    This is used to set the driver config ice_cpl_dt, equal to basedt/ICE_NCPL
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
   </entry>
 
@@ -298,7 +300,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>Number of ocn coupling intervals per NCPL_BASE_PERIOD.
-    Thisn is used to set the driver namelist ocn_cpl_dt, equal to basedt/OCN_NCPL
+    Thisn is used to set the driver config ocn_cpl_dt, equal to basedt/OCN_NCPL
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
   </entry>
 
@@ -357,7 +359,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>Number of rof coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist rof_cpl_dt, equal to basedt/ROF_NCPL
+    This is used to set the driver config rof_cpl_dt, equal to basedt/ROF_NCPL
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
   </entry>
 
@@ -367,7 +369,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>Number of wav coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist wav_cpl_dt, equal to basedt/WAV_NCPL
+    This is used to set the driver config wav_cpl_dt, equal to basedt/WAV_NCPL
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
   </entry>
 

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -102,7 +102,7 @@
 
   <entry id="CCSM_BGC">
     <type>char</type>
-    <valid_values>none,CO2A,CO2B,CO2C</valid_values>
+    <valid_values>none,CO2A,CO2B,CO2C,CO2C:DMS,CO2A:DMS</valid_values>
     <default_value>none</default_value>
     <values match="last">
       <value compset="_CAM">CO2A</value>
@@ -115,6 +115,11 @@
       <value compset="SSP.*_DATM.*_CLM">CO2A</value>
       <value compset="_BGC%BPRP">CO2C</value>
       <value compset="_BGC%BDRD">CO2C</value>
+      <value compset="_BGC%CO2C:DMS">CO2C:DMS</value>
+      <value compset="_BGC%CO2A:DMS">CO2A:DMS</value>
+      <value compset="_BGC%DMS">CO2A:DMS</value>
+      <value compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
+      <value compset="RCP.*_DATM%(QIA|CRU)" >CO2A</value>
       <value compset="20TR_DATM%IAF.*_BLOM%ECO">CO2A</value>
       <value compset="20TR_DATM%JRA.*_BLOM%ECO">CO2A</value>
     </values>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -113,15 +113,16 @@
       <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">CO2A</value>
       <value compset="HIST.*_DATM.*_CLM">CO2A</value>
       <value compset="SSP.*_DATM.*_CLM">CO2A</value>
-      <value compset="_BGC%BPRP">CO2C</value>
-      <value compset="_BGC%BDRD">CO2C</value>
       <value compset="_BGC%CO2C:DMS">CO2C:DMS</value>
       <value compset="_BGC%CO2A:DMS">CO2A:DMS</value>
-      <value compset="_BGC%DMS">CO2A:DMS</value>
+      <value compset="_BGC%DMS">DMS</value>
       <value compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
       <value compset="RCP.*_DATM%(QIA|CRU)" >CO2A</value>
       <value compset="20TR_DATM%IAF.*_BLOM%ECO">CO2A</value>
       <value compset="20TR_DATM%JRA.*_BLOM%ECO">CO2A</value>
+      <!-- The following two are here just for backwards compatibility -->
+      <value compset="_BGC%BPRP">CO2C</value>
+      <value compset="_BGC%BDRD">CO2C</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2387,10 +2387,9 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value BGC_MODE="CO2A.*">.true.</value>
+      <value BGC_MODE=".*CO2A.*">.true.</value>
     </values>
   </entry>
-
   <entry id="flds_co2b">
     <type>logical</type>
     <category>flds</category>
@@ -2402,10 +2401,9 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value BGC_MODE="CO2B">.true.</value>
+      <value BGC_MODE=".*CO2B.*">.true.</value>
     </values>
   </entry>
-
   <entry id="flds_co2c">
     <type>logical</type>
     <category>flds</category>
@@ -2417,7 +2415,23 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value BGC_MODE="CO2C">.true.</value>
+      <value BGC_MODE="BGC%.*CO2C.*">.true.</value>
+    </values>
+  </entry>
+
+  <entry id="flds_dms_med">
+    <type>logical</type>
+    <category>flds</category>
+    <group>ALLCOMP_attributes</group>
+    <desc>
+      Pass DMS flux computed in MED to both ATM and OCN
+      Set this by setting the xml variable BGC_MODE.
+      If BGC_MODE has 'DMSmed', then DMSmed will be set to .true.
+    </desc>
+    <values>
+      <value>.false.</value>
+      <value COMPSET=".*DMS.*">.true.</value>
+      <value COMPSET=".*_BLOM%ECO.*">.true.</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2430,7 +2430,7 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value COMPSET=".*DMS.*">.true.</value>
+      <value COMPSET="BGC%.*DMS.*">.true.</value>
       <value COMPSET=".*_BLOM%ECO.*">.true.</value>
     </values>
   </entry>

--- a/mediator/esmFlds.F90
+++ b/mediator/esmFlds.F90
@@ -793,7 +793,8 @@ contains
 
     if(present(rc)) rc = ESMF_SUCCESS
     if (.not. associated(fldnames) .or. .not. allocated(fields%mapindex)) then
-       write(msg, *) "med_fldList_GetFldNames: ERROR either fields or fldnames have not been allocated. ",associated(fldnames), allocated(fields%mapindex)
+       write(msg, *) "med_fldList_GetFldNames: ERROR either fields or fldnames have not been allocated. ",&
+            associated(fldnames), allocated(fields%mapindex)
        call ESMF_LogWrite(msg, ESMF_LOGMSG_ERROR)
        if(present(rc)) rc = ESMF_FAILURE
        return

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -3288,6 +3288,43 @@ contains
        end if
     endif
 
+    !=====================================================================
+    ! DMS EXCHANGE
+    !=====================================================================
+
+    ! Get dms concentration from ocn and compute dms flux in mediator and send to both atm and ocn
+    if (phase == 'advertise') then
+       call addfld_aoflux('Faox_dms')
+       call addfld_from(compocn, 'So_dms')
+       call addfld_to(compocn, 'Faox_dms')
+       call addfld_to(compatm, 'Faxx_dms')
+    else
+       ! TODO: this assumes that the aoflux grid is always the ocean
+       ! need to generalize this
+       if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_dms', rc=rc)) then
+          call addmrg_to(compatm , 'Faxx_dms', &
+               mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
+       end if
+       if ( fldchk(is_local%wrap%FBexp(compocn), 'Faox_dms', rc=rc) .and. &
+            fldchk(is_local%wrap%FBImp(compocn,compocn), 'So_dms', rc=rc) ) then
+          call addmrg_to(compocn, 'Faox_dms', &
+               mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
+       end if
+    end if
+
+    ! Get dms flux from ocn and send to atm (this is a deprecated functionality - only used for testing now)
+    if (phase == 'advertise') then
+       call addfld_from(compocn, 'Faoo_dms')
+       call addfld_to(compatm, 'Faxx_dms')
+    else
+       ! Note that Faoo_dmds should not be weighted by ifrac - since
+       ! it will be weighted by ifrac in the merge to the atm
+       if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_dms', rc=rc)) then
+          call addmrg_to(compatm , 'Faxx_dms', &
+               mrg_from=compmed, mrg_fld='Faoo_dms', mrg_type='merge', mrg_fracname='ofrac')
+       end if
+    end if
+
   end subroutine esmFldsExchange_cesm
 
 end module esmFldsExchange_cesm_mod

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -3299,20 +3299,28 @@ contains
        call addfld_to(compocn, 'Faox_dms')
        call addfld_to(compatm, 'Faxx_dms')
     else
-       ! TODO: this assumes that the aoflux grid is always the ocean
-       ! need to generalize this
-       if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_dms', rc=rc)) then
-          call addmrg_to(compatm , 'Faxx_dms', &
-               mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
-       end if
-       if ( fldchk(is_local%wrap%FBexp(compocn), 'Faox_dms', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compocn,compocn), 'So_dms', rc=rc) ) then
-          call addmrg_to(compocn, 'Faox_dms', &
-               mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
+       if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
+          ! TODO: extend this to to agrid and xgrid
+          if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_dms', rc=rc)) then
+             call addmrg_to(compatm , 'Faxx_dms', &
+                  mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
+          end if
+          if ( fldchk(is_local%wrap%FBexp(compocn), 'Faox_dms', rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compocn,compocn), 'So_dms', rc=rc) ) then
+             call addmrg_to(compocn, 'Faox_dms', &
+                  mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
+          end if
+       else
+          call ESMF_LogWrite(trim(subname)//&
+               ": only ogrid has been enabled for dms flux computation", &
+               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
+          rc = ESMF_FAILURE
+          return
        end if
     end if
 
     ! Get dms flux from ocn and send to atm (this is a deprecated functionality - only used for testing now)
+    ! TODO: remove this 
     if (phase == 'advertise') then
        call addfld_from(compocn, 'Faoo_dms')
        call addfld_to(compatm, 'Faxx_dms')

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1213,16 +1213,13 @@
        description: DMS uppoer ocean concentration
      #
      - standard_name: Faoo_dms
-       alias: surface_upward_flux_of_dimethyl_sulfide
        canonical_units: moles m-2 s-1
-       description: Surface flux of DMS computed in ocean
+       description: Surface flux of DMS computed in ocean (downward positive)
      #
      - standard_name: Faox_dms
-       alias: surface_upward_flux_of_dimethyl_sulfide
        canonical_units: moles m-2 s-1
-       description: Surface flux of DMS computed in mediator
+       description: Surface flux of DMS computed in mediator (downward positive)
      #
      - standard_name: Faxx_dms
-       alias: surface_upward_flux_of_dimethyl_sulfide
        canonical_units: moles m-2 s-1
-       description: merged surface flux of DMS to atm
+       description: merged surface flux of DMS to atm (downward positive)

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -30,21 +30,17 @@
      - standard_name: Faox_lwup
        alias: mean_up_lw_flx_ocn
        canonical_units: W m-2
-       description: mediator export - long wave radiation flux over the ocean
+       description: long wave radiation flux over the ocean computed in mediator
      #
      - standard_name: Faox_taux
        alias: stress_on_air_ocn_zonal
        canonical_units: N m-2
-       description: mediator export
+       description: zonal stress on ocean/air computed in mediator
      #
      - standard_name: Faox_tauy
        alias: stress_on_air_ocn_merid
        canonical_units: N m-2
-       description: mediator export
-     #
-     - standard_name: area
-       canonical_units: radians**2
-       description: mediator area for component
+       description: meridional stress on ocean/air computed in mediator
      #
      #-----------------------------------
      # section: land export
@@ -1203,3 +1199,30 @@
      #
      - standard_name: mask
        canonical_units: 1
+     #
+     - standard_name: area
+       canonical_units: radians**2
+       description: mediator area for component
+     #
+     #-----------------------------------
+     # section: dms exchange
+     #-----------------------------------
+     #
+     - standard_name: So_dms
+       canonical_units: nmol L-1
+       description: DMS uppoer ocean concentration
+     #
+     - standard_name: Faoo_dms
+       alias: surface_upward_flux_of_dimethyl_sulfide
+       canonical_units: moles m-2 s-1
+       description: Surface flux of DMS computed in ocean
+     #
+     - standard_name: Faox_dms
+       alias: surface_upward_flux_of_dimethyl_sulfide
+       canonical_units: moles m-2 s-1
+       description: Surface flux of DMS computed in mediator
+     #
+     - standard_name: Faxx_dms
+       alias: surface_upward_flux_of_dimethyl_sulfide
+       canonical_units: moles m-2 s-1
+       description: merged surface flux of DMS to atm

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -1211,56 +1211,6 @@ contains
           ! The following comes from the BLOM/iHAMOCC routine carchm.F90
           ! See https://noresm-docs.readthedocs.io/en/noresm2/model-description/ocn_bgc_model.html
           do n = 1,size(sst)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
              sst_c = sst(n) - tfrz
              sst_c = min(40.,max(-3., sst_c))
              scdms = 2855.7+  (-177.63 + (6.0438 + (-0.11645 + 0.00094743*sst_c)*sst_c)*sst_c)*sst_c


### PR DESCRIPTION
### Description of changes
new dms flux capability in mediator

### Specific notes

This PR enables dms fluxes to be computed by CMEPS and sent back to the ocn and atm OR to have DMS fluxes from the ocean routed to the atm.
The behavior is  governed by a new CMEPS configuration variable, `flds_dms_med`  in nuopc.`runconfig`. 
- If `flds_dms_med` is .true., then `So_dms` is expected from the ocean and CMEPS will compute Faox_dms and sent back the dms flux to the ocean and to the atm.
- If `flds_dms_med` is .false., then it is expected that a dms flux `Faoo_dms` will be sent from the ocean and routed to the atm. 
 
The default behavior moving fowards will be to have the ocean send concentrations and to have the mediator compute fluxes.
DMS fluxes will not always be exchanged between the ocn,atm and mediator. Although CMEPS will advertise these fields, it is up to the ocean component (e.g. BLOM or DOCN) to advertise that it will be sending either DMS fluxes or concentrations. 

In addition a new naming convention has been added for the BGC% attribute of the compset. 
CCSM_BGC is now a colon delimited string of fluxes descriptions (e.g. CO2A:DMS) that can be exchanged between components. As an example, if both DMS and CO2A are exchanged - then the attribute should be BGC%CO2A:DMS OR BGC%DMS:CO2A - thereby permitting a more general scheme of determine which fluxes will be exchanged between components.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: #8 

Are changes expected to change answers? bfb(specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)? Yes
flds_dms_med has been added as a new config option

### Testing performed
On Betzy, verified that ERS_Ld3.T62_tn14.NOINYOC and ERS_Ld3.T62_tn14.NOINY worked with the accompanying BLOM changes.
No testing was done with the out of the box noresm_develop_v6 and just this cmeps change. However, since the ERS_Ld3.T62_tn14.NOINY does not include any dms exchange - it would effectively have done this.
