### PR TITLE
addition of atm_ncpl for ww3dev testing

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -241,6 +241,10 @@
       <!-- High res BLOM -->
       <!-- =================================================== -->
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
+      <!-- =================================================== -->
+      <!-- High res WW3DEV -->
+      <!-- =================================================== -->
+      <value compset="_WW3DEV" grid="w%w025">72</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -242,7 +242,12 @@
       <!-- =================================================== -->
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
       <!-- =================================================== -->
-      <!-- High res WW3DEV -->
+      <!-- WW3DEV Testing -->
+      <!-- This can be used for testing but is incompatible with many -->
+      <!-- coupled compsets (e.g., 1/2 degree needs 96, higher-top models -->
+      <!-- often need shorter intervals). I think this section should -->
+      <!-- (eventually) be expanded with more entries for different -->
+      <!-- atmosphere (and ocean) configurations and resolutions. -->
       <!-- =================================================== -->
       <value compset="_WW3DEV" grid="w%w025">72</value>
     </values>


### PR DESCRIPTION
### Description of changes
For the new ww3dev resolution w025 - ATM_NCPL must be set to 72

### Specific notes

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers? bfb

Any User Interface Change: No

### Testing performed
Verified that ERS_Ld3.T62_w025.WW3test.betzy_intel now works out of the box

