### PR TITLE
new flds to cmeps from ww3 for auxiliary averaged otuput

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -784,6 +784,34 @@
       If TRUE, the component libraries are always built with OpenMP capability.</desc>
   </entry>
 
+  <entry id="GPU_TYPE">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If set will compile and submit with this gpu type enabled </desc>
+  </entry>
+
+  <entry id="GPU_OFFLOAD">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If set will compile and submit with this gpu offload method enabled </desc>
+  </entry>
+
+  <entry id="MPI_GPU_WRAPPER_SCRIPT">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If set will attach this script to the MPI run command, mapping
+    different MPI ranks to different GPUs within the same compute node</desc>
+  </entry>
+
   <entry id="SMP_PRESENT">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
@@ -1798,12 +1826,22 @@
     <desc>pes or cores per node for accounting purposes </desc>
   </entry>
 
+  <entry id="MAX_CPUTASKS_PER_GPU_NODE">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <values>
+      <value compiler="nvhpc">1</value>
+    </values>
+    <group>mach_pes_last</group>
+    <file>env_mach_pes.xml</file>
+    <desc> Number of CPU cores per GPU node used for simulation </desc>
+  </entry>
+
   <entry id="NGPUS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>
     <values>
-      <value compiler="pgi-gpu">1</value>
-      <value compiler="nvhpc-gpu">1</value>
+      <value compiler="nvhpc">1</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -716,6 +716,17 @@
       <value>$ESMF_VERBOSITY_LEVEL</value>
     </values>
   </entry>
+  <entry id="check_for_nans">
+    <type>logical</type>
+    <category>performance</category>
+    <group>MED_attributes</group>
+    <desc>
+      Check for NaN values in fields returned from mediator to components.  This has a small performance impact.
+    </desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
   <entry id="atm_nx" modify_via_xml="ATM_NX">
     <type>integer</type>
     <category>control</category>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2092,14 +2092,14 @@
   </entry>
 
   <!-- ======================================= -->
-  <!-- MED ocn history files -->
+  <!-- MED auxiliary wav2med history files -->
   <!-- ======================================= -->
 
   <entry id="histaux_wav2med_file1_enabled">
     <type>logical</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>Auxiliary mediator wav2med average history output every day.</desc>
+    <desc>Auxiliary mediator wav2med file1 output enabled if true</desc>
     <values>
       <value>.false.</value>
     </values>
@@ -2108,7 +2108,7 @@
     <type>char</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>Auxiliary mediator wav2med average history output every day.</desc>
+    <desc>Auxiliary mediator wav2med file1 output fields (colon delimited)</desc>
     <values>
       <value>Sw_hs:Sw_wlm:Sw_thm:Sw_thp0:Sw_fp0:Sw_u:Sw_v:Sw_ustokes:Sw_vstokes:Sw_tusx:Sw_tusy</value>
     </values>
@@ -2117,7 +2117,7 @@
     <type>char</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>history option type</desc>
+    <desc>Auxiliary mediator wav2med file1 output option</desc>
     <values>
       <value>ndays</value>
     </values>
@@ -2126,7 +2126,7 @@
     <type>integer</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>history option type</desc>
+    <desc>Auxiliary mediator wav2med file1 output frequency (used for option type)</desc>
     <values>
       <value>1</value>
     </values>
@@ -2135,7 +2135,7 @@
     <type>logical</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>If true, use time average for aux file output.</desc>
+    <desc>Auxiliary mediator wav2med file1 time averaged flag for file output.</desc> 
     <values>
       <value>.true.</value>
     </values>
@@ -2144,7 +2144,7 @@
     <type>char</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>Auxiliary name identifier in history name</desc>
+    <desc>Auxiliary mediator wav2med file1 name identifier. By default will be wav.24h.avg</desc>
     <values>
       <value>wav.24h.avg</value>
     </values>
@@ -2153,7 +2153,7 @@
     <type>integer</type>
     <category>aux_hist</category>
     <group>MED_attributes</group>
-    <desc>Number of time samples per file.</desc>
+    <desc>Auxiliary mediator wav2med file1 number of time samples per file. By default will be 30</desc>
     <values>
       <value>30</value>
     </values>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2080,6 +2080,74 @@
     </values>
   </entry>
 
+  <!-- ======================================= -->
+  <!-- MED ocn history files -->
+  <!-- ======================================= -->
+
+  <entry id="histaux_wav2med_file1_enabled">
+    <type>logical</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>Auxiliary mediator wav2med average history output every day.</desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+  <entry id="histaux_wav2med_file1_flds">
+    <type>char</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>Auxiliary mediator wav2med average history output every day.</desc>
+    <values>
+      <value>Sw_hs:Sw_wlm:Sw_thm:Sw_thp0:Sw_fp0:Sw_u:Sw_v:Sw_ustokes:Sw_vstokes:Sw_tusx:Sw_tusy</value>
+    </values>
+  </entry>
+  <entry id="histaux_wav2med_file1_history_option">
+    <type>char</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>history option type</desc>
+    <values>
+      <value>ndays</value>
+    </values>
+  </entry>
+  <entry id="histaux_wav2med_file1_history_n">
+    <type>integer</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>history option type</desc>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+  <entry id="histaux_wav2med_file1_doavg">
+    <type>logical</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>If true, use time average for aux file output.</desc>
+    <values>
+      <value>.true.</value>
+    </values>
+  </entry>
+  <entry id="histaux_wav2med_file1_auxname">
+    <type>char</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>Auxiliary name identifier in history name</desc>
+    <values>
+      <value>wav.24h.avg</value>
+    </values>
+  </entry>
+  <entry id="histaux_wav2med_file1_ntperfile">
+    <type>integer</type>
+    <category>aux_hist</category>
+    <group>MED_attributes</group>
+    <desc>Number of time samples per file.</desc>
+    <values>
+      <value>30</value>
+    </values>
+  </entry>
+
   <!-- =========================== -->
   <!-- MED mapping attributes      -->
   <!-- =========================== -->

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -2264,6 +2264,21 @@ contains
     end if
 
     !-----------------------------
+    ! from wav: for auxiliary purposes only
+    !-----------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compwav, 'Sw_hs')
+       call addfld_from(compwav, 'Sw_wlm')
+       call addfld_from(compwav, 'Sw_thm')
+       call addfld_from(compwav, 'Sw_thp0')
+       call addfld_from(compwav, 'Sw_fp0')
+       call addfld_from(compwav, 'Sw_u')
+       call addfld_from(compwav, 'Sw_v')
+       call addfld_from(compwav, 'Sw_tusx')
+       call addfld_from(compwav, 'Sw_tusy')
+    end if
+
+    !-----------------------------
     ! to ocn: Langmuir multiplier from wave
     !-----------------------------
     if (phase == 'advertise') then

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1165,7 +1165,42 @@
      - standard_name: Sw_pstokes_y
        canonical_units: m/s
        description: Northward partitioned stokes drift components
-
+     #
+     - standard_name: Sw_hs
+       canonical_units: m
+       description: Significant wave hight (only needed for mediatory history output)
+     #
+     - standard_name: Sw_wlm
+       canonical_units: m
+       description: Mean wave length (only needed for mediatory history output)
+     #
+     - standard_name: Sw_thm
+       canonical_units: unitless
+       description: Mean wave direction (only needed for mediatory history output)
+     #
+     - standard_name: Sw_thp0
+       canonical_units: unitless
+       description: Peak wave direction (only needed for mediatory history output)
+     #
+     - standard_name: Sw_fp0
+       canonical_units: 1/s
+       description: Peak wave frequency (only needed for mediatory history output)
+     #
+     - standard_name: Sw_u
+       canonical_units: m/s
+       description: Surface wind zonal (only needed for mediatory history output)
+     #
+     - standard_name: Sw_v
+       canonical_units: m/s
+       description: Surface wind meridional (only needed for mediatory history output)
+     #
+     - standard_name: Sw_tusx
+       canonical_units: m2/s
+       description: Stokes zonal transport vector (only needed for mediatory history output)
+     #
+     - standard_name: Sw_tusy
+       canonical_units: m2/s
+       description: Stokes meridional transport vector (only needed for mediatory history output)
      #
      - standard_name: Sw_elevation_spectrum
        alias: wave_elevation_spectrum


### PR DESCRIPTION
### Description of changes
Introduction of new fields from ww3dev that can be used for time averaged auxiliary output.

### Specific notes
WW3dev does not have the capability to do time averaged output. By sending these 2d fields to CMEPS and adding them as options to auxiliary output - analysis can be done on time averaged output from ww3dev without needing to introduce new changes in ww3 for time averaged output.

Contributors other than yourself, if any:

CMEPS Issues Fixed:

Are changes expected to change answers?  bfb

Any User Interface Changes (namelist or namelist defaults changes)? New auxiliary output fields introduced in nuopc.runconfig.

### Testing performed
Verified that the new fields were indeed sent from ww3 and gave reasonable results.
Test was SMS_Ld10.T62_wtn14nw.WW3test.betzy_intel.


