### PR TITLE
make histaux_wav2med_file1_enabled an ALLCOMPS attribute

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2098,11 +2098,12 @@
   <entry id="histaux_wav2med_file1_enabled">
     <type>logical</type>
     <category>aux_hist</category>
-    <group>MED_attributes</group>
+    <group>ALLCOMP_attributes</group>
     <desc>Auxiliary mediator wav2med file1 output enabled if true</desc>
     <values>
       <value>.false.</value>
     </values>
+    <desc>Note that ww3dev will obtain this configuration variable and send the fields needed for wav2med</desc>
   </entry>
   <entry id="histaux_wav2med_file1_flds">
     <type>char</type>


### PR DESCRIPTION
### Description of changes
make histaux_wav2med_file1_enabled an ALLCOMPS attribute

### Specific notes
made histaux_wav2med_file1_enabled an ALLCOMPS attribute in order for ww3dev to query this variable in order to determine if new fields need to get sent to the mediator for aux history output.
This change is needed for https://github.com/NorESMhub/WW3/pull/11.


Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

