### PR TITLE
export state to glc added to lnd2glc auxiliary file

### DIFF
--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -25,7 +25,7 @@ module med_phases_history_mod
   use med_io_mod            , only : med_io_write, med_io_wopen, med_io_enddef, med_io_close
   use perf_mod              , only : t_startf, t_stopf
   use pio                   , only : file_desc_t
-  
+
   implicit none
   private
 
@@ -515,19 +515,20 @@ contains
   end subroutine med_phases_history_write_med
 
   !===============================================================================
-  subroutine med_phases_history_write_lnd2glc(gcomp, fldbun, rc)
+  subroutine med_phases_history_write_lnd2glc(gcomp, fldbun_lnd, rc, fldbun_glc)
 
-    ! Write yearly average of lnd -> glc fields
+    ! Write yearly average of lnd -> glc fields on both land and glc grids
 
-    use med_internalstate_mod, only : complnd
+    use med_internalstate_mod, only : complnd, compglc
     use med_constants_mod , only : SecPerDay => med_constants_SecPerDay
     use med_io_mod        , only : med_io_write_time, med_io_define_time
     use med_io_mod        , only : med_io_date2yyyymmdd, med_io_sec2hms, med_io_ymd2date
 
     ! input/output variables
     type(ESMF_GridComp)    , intent(in)  :: gcomp
-    type(ESMF_FieldBundle) , intent(in)  :: fldbun
+    type(ESMF_FieldBundle) , intent(in)  :: fldbun_lnd
     integer                , intent(out) :: rc
+    type(ESMF_FieldBundle) , intent(in), optional :: fldbun_glc(:)
 
     ! local variables
     type(file_desc_t)       :: io_file
@@ -546,8 +547,9 @@ contains
     real(r8)                :: time_val     ! time coordinate output
     real(r8)                :: time_bnds(2) ! time bounds output
     character(len=CL)       :: hist_file
-    integer                 :: m
+    integer                 :: m,n
     logical                 :: isPresent
+    character(len=CS)       :: cvalue
     character(len=*), parameter :: subname='(med_phases_history_write_lnd2glc)'
     !---------------------------------------
 
@@ -619,9 +621,21 @@ contains
           call med_io_write_time(io_file, time_val, time_bnds, nt=1, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
-       call med_io_write(io_file, fldbun, whead(m), wdata(m), is_local%wrap%nx(complnd), is_local%wrap%ny(complnd), &
+
+       call med_io_write(io_file, fldbun_lnd, whead(m), wdata(m), &
+            is_local%wrap%nx(complnd), is_local%wrap%ny(complnd), &
             nt=1, pre=trim(compname(complnd))//'Imp', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (present(fldbun_glc)) then
+          do n = 1,size(fldbun_glc)
+             call med_io_write(io_file, fldbun_glc(n), whead(m), wdata(m), &
+                  is_local%wrap%nx(compglc(n)), is_local%wrap%ny(compglc(n)), &
+                  nt=1, pre=trim(compname(compglc(n)))//'Exp', rc=rc)
+             if (ChkErr(rc,__LINE__,u_FILE_u)) return
+          end do
+       end if
+
     end do ! end of loop over m
 
     ! Close history file


### PR DESCRIPTION
### Description of changes
Permits export state to glc to be added to the lnd2glc auxiliary file 

### Specific notes
Before this PR the lnd2glc auxiliary file only had the import states from lnd to glc with elevation classes on the land grid. There was the desire to also have the export state to glc (downscaled without elevation classes) put in place.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers? None

Any User Interface Changes? No

### Testing performed
Using the sandbox https://github.com/mvertens/NorESM.git noresm2_5_alpha01_cism
Verified that running the following have the desired behavior:

> ./create_newcase --case test_cism --compset 1850_DATM%GSWP3v1_CLM50%SP_SICE_SOCN_SROF_CISM2%GRIS-EVOLVE_SWAV --res f45_f45_mg37 --run-unsupported
> cd test_cism
> ./xmlchange GLC_AVG_PERIOD=glc_coupling_period
> ./xmlchange HIST_N=1
> ./xmlchange HIST_OPTION=ndays
> [edit user_nl_cpl to have histaux_l2x1yrg = .true.]

I obtained the following files:
test_cism.cpl.hi.0001-01-02-00000.nc
test_cism.cpl.hi.0001-01-03-00000.nc
test_cism.cpl.hi.0001-01-04-00000.nc
test_cism.cpl.hi.0001-01-05-00000.nc
test_cism.cpl.hx.1yr2glc.0001-01-02-00000.nc
test_cism.cpl.hx.1yr2glc.0001-01-03-00000.nc
test_cism.cpl.hx.1yr2glc.0001-01-04-00000.nc
test_cism.cpl.hx.1yr2glc.0001-01-05-00000.nc
test_cism.cpl.hx.1yr2glc.0001-01-06-00000.nc

I verified that the export state in the cpl.hx file looked the same as in the cpl.hi file.