### PR TITLE
removed changes introduced to compute dms fluxes in mediator

### DIFF
--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -1559,6 +1559,22 @@ contains
        end if
     end if
 
+    !-----------------------------------------------------------------------------
+    ! to atm: dms flux from ocean
+    !-----------------------------------------------------------------------------
+    if (phase == 'advertise') then
+       call addfld_from(compocn, 'Faoo_fdms_ocn')
+       call addfld_to(compatm, 'Faoo_fdms_ocn')
+    else
+       if ( fldchk(is_local%wrap%FBImp(compocn, compocn), 'Faoo_fdms_ocn', rc=rc) .and. &
+            fldchk(is_local%wrap%FBExp(compatm)         , 'Faoo_fdms_ocn', rc=rc)) then
+          call addmap_from(compocn, 'Faoo_fdms_ocn', compatm, mapconsd, 'one', ocn2atm_map)
+          call addmrg_to(compatm , 'Faoo_fdms_ocn', &
+               mrg_from=compocn, mrg_fld='Faoo_fdms_ocn', mrg_type='merge', mrg_fracname='ofrac')
+          ! TODO: does this need a custom merge like Faoo_fco2_ocn ???
+       end if
+    end if
+
     !=====================================================================
     ! FIELDS TO OCEAN (compocn)
     !=====================================================================
@@ -3311,51 +3327,6 @@ contains
           ! custom merge in med_phases_prep_atm
        end if
     endif
-
-    !=====================================================================
-    ! DMS EXCHANGE
-    !=====================================================================
-
-    ! Get dms concentration from ocn and compute dms flux in mediator and send to both atm and ocn
-    if (phase == 'advertise') then
-       call addfld_aoflux('Faox_dms')
-       call addfld_from(compocn, 'So_dms')
-       call addfld_to(compocn, 'Faox_dms')
-       call addfld_to(compatm, 'Faxx_dms')
-    else
-       if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
-          ! TODO: extend this to to agrid and xgrid
-          if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_dms', rc=rc)) then
-             call addmrg_to(compatm , 'Faxx_dms', &
-                  mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
-          end if
-          if ( fldchk(is_local%wrap%FBexp(compocn), 'Faox_dms', rc=rc) .and. &
-               fldchk(is_local%wrap%FBImp(compocn,compocn), 'So_dms', rc=rc) ) then
-             call addmrg_to(compocn, 'Faox_dms', &
-                  mrg_from=compmed, mrg_fld='Faox_dms', mrg_type='merge', mrg_fracname='ofrac')
-          end if
-       else
-          call ESMF_LogWrite(trim(subname)//&
-               ": only ogrid has been enabled for dms flux computation", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
-       end if
-    end if
-
-    ! Get dms flux from ocn and send to atm (this is a deprecated functionality - only used for testing now)
-    ! TODO: remove this
-    if (phase == 'advertise') then
-       call addfld_from(compocn, 'Faoo_dms')
-       call addfld_to(compatm, 'Faxx_dms')
-    else
-       ! Note that Faoo_dmds should not be weighted by ifrac - since
-       ! it will be weighted by ifrac in the merge to the atm
-       if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_dms', rc=rc)) then
-          call addmrg_to(compatm , 'Faxx_dms', &
-               mrg_from=compmed, mrg_fld='Faoo_dms', mrg_type='merge', mrg_fracname='ofrac')
-       end if
-    end if
 
   end subroutine esmFldsExchange_cesm
 

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1282,21 +1282,9 @@
        description: mediator area for component
      #
      #-----------------------------------
-     # section: dms exchange
+     # section: dms exchange ocn->atm
      #-----------------------------------
      #
-     - standard_name: So_dms
-       canonical_units: nmol L-1
-       description: DMS uppoer ocean concentration
-     #
-     - standard_name: Faoo_dms
+     - standard_name: Faoo_fdms_ocn
        canonical_units: moles m-2 s-1
        description: Surface flux of DMS computed in ocean (downward positive)
-     #
-     - standard_name: Faox_dms
-       canonical_units: moles m-2 s-1
-       description: Surface flux of DMS computed in mediator (downward positive)
-     #
-     - standard_name: Faxx_dms
-       canonical_units: moles m-2 s-1
-       description: merged surface flux of DMS to atm (downward positive)

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -35,15 +35,9 @@ module med_phases_aofluxes_mod
 #ifndef CESMCOUPLED
   use ufs_const_mod         , only : rearth => SHR_CONST_REARTH
   use ufs_const_mod         , only : pi => SHR_CONST_PI
-  use ufs_const_mod         , only : tfrz => SHR_CONST_TKFRZ
-  use ufs_const_mod         , only : rdair => SHR_CONST_RDAIR
-  use ufs_const_mod         , only : cpdair => SHR_CONST_CPDAIR
-#ELSE
+#else
   use shr_const_mod         , only : rearth => SHR_CONST_REARTH
   use shr_const_mod         , only : pi => SHR_CONST_PI
-  use shr_const_mod         , only : tfrz => SHR_CONST_TKFRZ
-  use shr_const_mod         , only : rdair => SHR_CONST_RDAIR
-  use shr_const_mod         , only : cpdair => SHR_CONST_CPDAIR
 #endif
 
   implicit none
@@ -80,13 +74,9 @@ module med_phases_aofluxes_mod
   ! Private data
   !--------------------------------------------------------------------------
 
-  real(r8), parameter :: rcp = rdair/cpdair ! gas constant of air / specific heat capacity at a constant pressure
-
-  logical :: flds_wiso    ! use case
-
+  logical :: flds_wiso  ! use case
   logical :: compute_atm_dens
   logical :: compute_atm_thbot
-  logical :: compute_dms_flux
   integer :: ocn_surface_flux_scheme ! use case
 
   character(len=CS), pointer :: fldnames_ocn_in(:)
@@ -119,8 +109,6 @@ module med_phases_aofluxes_mod
      real(R8) , pointer :: roce_16O    (:) => null() ! ocn H2O ratio
      real(R8) , pointer :: roce_HDO    (:) => null() ! ocn HDO ratio
      real(R8) , pointer :: roce_18O    (:) => null() ! ocn H218O ratio
-     real(R8) , pointer :: dms_ocn     (:) => null() ! ocn dms concentration
-
      ! input: atm
      real(R8) , pointer :: zbot        (:) => null() ! atm level height
      real(R8) , pointer :: ubot        (:) => null() ! atm velocity, zonal
@@ -137,7 +125,6 @@ module med_phases_aofluxes_mod
      real(R8) , pointer :: shum_HDO    (:) => null() ! atm HDO tracer
      real(R8) , pointer :: shum_18O    (:) => null() ! atm H218O tracer
      real(R8) , pointer :: lwdn        (:) => null() ! atm downward longwave heat flux
-
      ! local size and computational mask and area: on aoflux grid
      integer            :: lsize                     ! local size
      integer  , pointer :: mask        (:) => null() ! integer ocn domain mask: 0 <=> inactive cell
@@ -162,7 +149,6 @@ module med_phases_aofluxes_mod
      real(R8) , pointer :: ustar       (:) => null() ! saved ustar
      real(R8) , pointer :: re          (:) => null() ! saved re
      real(R8) , pointer :: ssq         (:) => null() ! saved sq
-     real(R8) , pointer :: dms         (:) => null() ! ocn-> atm dms flux (optional) 
   end type aoflux_out_type
 
   character(*), parameter :: u_FILE_u = &
@@ -243,8 +229,8 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
        if (maintask) then
-          write(logunit,'(a)') trim(subname)//' initialized FB for '// &
-               trim(compname(compatm))//'->'//trim(compname(compocn))
+          write(logunit,'(a)') trim(subname)//' initializing FB for '// &
+               trim(compname(compatm))//'_'//trim(compname(compocn))
        end if
 
        ! Create the field bundle is_local%wrap%FBImp(compocn,compatm) if needed
@@ -258,8 +244,8 @@ contains
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        end if
        if (maintask) then
-          write(logunit,'(a)') trim(subname)//' initialized FB for '// &
-               trim(compname(compocn))//'->'//trim(compname(compatm))
+          write(logunit,'(a)') trim(subname)//' initializing FB for '// &
+               trim(compname(compocn))//'_'//trim(compname(compatm))
        end if
 
     end if
@@ -427,15 +413,6 @@ contains
        compute_atm_dens = .false.
     else
        compute_atm_dens = .true.
-    end if
-
-    ! Determine if dms flux will be computed in mediator
-    if (   FB_fldchk(is_local%wrap%FBImp(compocn,compocn), 'So_dms', rc=rc ) .and. &
-         ( FB_fldchk(is_local%wrap%FBExp(compocn), 'Faox_dms', rc=rc) .or. &
-           FB_fldchk(is_local%wrap%FBExp(compatm), 'Faxx_dms', rc=rc) ) ) then
-       compute_dms_flux = .true.
-    else
-       compute_dms_flux = .false.
     end if
 
     !----------------------------------
@@ -991,22 +968,16 @@ contains
     integer               , intent(out)   :: rc
     !
     ! Local variables
-    type(InternalState)    :: is_local
-    integer                :: n                  ! indices
-    real(r8), parameter    :: qmin = 1.0e-8_r8   ! minimum
-    real(r8), parameter    :: p0 = 100000.0_r8   ! reference pressure in Pa
-    real(r8), parameter    :: Xconvxa= 6.97e-07  ! Wanninkhof's a=0.251 converted to ms-1/(ms-1)^2 
-    integer                :: maptype
-    type(ESMF_Field)       :: field_src
-    type(ESMF_Field)       :: field_dst
-    real(r8)               :: sst_c
-    real(r8)               :: scdms
-    real(r8)               :: kwdms
-    real(r8), pointer      :: odms(:)
-    real(r8), pointer      :: sst(:)
-    real(r8), pointer      :: u10m(:)
-    real(r8), pointer      :: flux_dms(:)
-    character(*),parameter :: subName = '(med_aofluxes_update) '
+    type(InternalState)      :: is_local
+    integer                  :: n                          ! indices
+    real(r8), parameter      :: qmin = 1.0e-8_r8
+    real(r8), parameter      :: p0 = 100000.0_r8           ! reference pressure in Pa
+    real(r8), parameter      :: rcp = 0.286_r8             ! gas constant of air / specific heat capacity at a constant pressure
+    real(r8), parameter      :: rdair = 287.058_r8         ! dry air gas constant in J/K/kg
+    integer                  :: maptype
+    type(ESMF_Field)         :: field_src
+    type(ESMF_Field)         :: field_dst
+    character(*),parameter   :: subName = '(med_aofluxes_update) '
     !-----------------------------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -1178,52 +1149,6 @@ contains
             routehandle=is_local%wrap%RH(compocn, compwav, maptype), &
             termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-    end if
-
-    ! compute DMS fluxes to atm and ocn
-    if (compute_dms_flux) then
-       if (is_local%wrap%aoflux_grid == 'ogrid') then
-          ! TODO: extend this to to agrid and xgrid
-
-          call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compocn), 'So_dms', field=field_src, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(field_src, farrayptr=odms, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-          call ESMF_FieldBundleGet(is_local%wrap%FBImp(compocn,compocn), 'So_t', field=field_src, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(field_src, farrayptr=sst, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-          call ESMF_FieldBundleGet(is_local%wrap%FBMed_aoflux_o, 'So_u10', field=field_src, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(field_src, farrayptr=u10m, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-          call ESMF_FieldBundleGet(is_local%wrap%FBMed_aoflux_o, 'Faox_dms', field=field_src, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-          call ESMF_FieldGet(field_src, farrayptr=flux_dms, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-
-          ! flux_dms from ocean is in kg/m2/s
-          ! flux is downwards positive - therefore negative values to
-          ! the atmosphere (this is the opposite of what is there in BLOM)
-          ! The following comes from the BLOM/iHAMOCC routine carchm.F90
-          ! See https://noresm-docs.readthedocs.io/en/noresm2/model-description/ocn_bgc_model.html
-          do n = 1,size(sst)
-             sst_c = sst(n) - tfrz
-             sst_c = min(40.,max(-3., sst_c))
-             scdms = 2855.7+  (-177.63 + (6.0438 + (-0.11645 + 0.00094743*sst_c)*sst_c)*sst_c)*sst_c
-             kwdms = Xconvxa * u10m(n)**2 * (660./scdms)**0.5 
-             flux_dms(n) = -62.13 *kwdms * odms(n)
-          end do
-       else
-          call ESMF_LogWrite(trim(subname)//&
-               ": only ogrid has been enabled for dms flux computation", &
-               ESMF_LOGMSG_ERROR, line=__LINE__, file=u_FILE_u)
-          rc = ESMF_FAILURE
-          return
-       end if
     end if
 
     call t_stopf('MED:'//subname)
@@ -1738,11 +1663,6 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        allocate(aoflux_in%roce_HDO(aoflux_in%lsize)); aoflux_in%roce_HDO(:) = 0._R8
     end if
 
-    if ( compute_dms_flux) then
-       call fldbun_getfldptr(fldbun_o, 'So_dms', aoflux_in%dms_ocn, xgrid=xgrid, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-    end if
-
   end subroutine set_aoflux_in_pointers
 
   !================================================================================
@@ -1795,10 +1715,6 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
        allocate(aoflux_out%evap_16O(lsize)); aoflux_out%evap_16O(:) = 0._R8
        allocate(aoflux_out%evap_18O(lsize)); aoflux_out%evap_18O(:) = 0._R8
        allocate(aoflux_out%evap_HDO(lsize)); aoflux_out%evap_HDO(:) = 0._R8
-    end if
-    if (compute_dms_flux) then
-       call fldbun_getfldptr(fldbun, 'Faox_dms', aoflux_out%dms, xgrid=xgrid, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
 
   end subroutine set_aoflux_out_pointers


### PR DESCRIPTION
### Description of changes
removed changes introduced to compute dms fluxes in mediator

### Specific notes
After prototyping and testing, the computation dms fluxes in the mediator is not a good long term solution. So for now this is removed and the original approach of computing DMS fluxes from ocn->atm will be kept in BLOM.

Contributors other than yourself, if any: None

CMEPS Issues Fixed:  None

Are changes expected to change answers? bfb

Any User Interface Changes: None

### Testing performed
Verified that SMS_D_Ln9_P256.f19_f19_mtn14.F2000climo.betzy_intel.cam-outfrq9s
No other tests were done since at this point DMS fluxes are not being sent from BLOM to CAM and this particular code was not activated in any tests.