### PR TITLE
Adjust eps_imesh for tnx2 grid in namelist to omit crash at mesh chec…

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -3935,7 +3935,7 @@
       Maximum allowed mesh error
     </desc>
     <values>
-      <value>0.01</value>
+      <value>0.1</value>
       <value ocn_grid="tnx2v1">0.15</value>
     </values>
   </entry>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -3927,6 +3927,18 @@
       <value>$ICE_DOMAIN_MESH</value>
     </values>
   </entry>
+  <entry id="eps_imesh">
+    <type>real</type>
+    <category>mapping</category>
+    <group>ICE_attributes</group>
+    <desc>
+      Maximum allowed mesh error
+    </desc>
+    <values>
+      <value>0.01</value>
+      <value ocn_grid="tnx2v1">0.15</value>
+    </values>
+  </entry>
 
   <!-- ======================================== -->
   <!--  GLC attributes                          -->


### PR DESCRIPTION
fixes #28

### Description of changes
Included eps_imesh in namelist to avoid crash during ice mesh check.

### Specific notes

Contributors other than yourself, if any:
@gold2718 , @JorgSchwinger, @TomasTorsvik 

CMEPS Issues Fixed (include github issue #):
https://github.com/NorESMhub/CMEPS/issues/28

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 
No.

Any User Interface Changes (namelist or namelist defaults changes)?
Yes, `eps_imesh` introduced and changed for tnx2 grid to avoid crash.

### Testing performed
Two test were carried out on betzy - both compset `NOINYOC`, one `tnx2` and one `tnx1` run. In the case of `tnx2`, the `eps_imesh=0.15` value was picked up and in the case of `tnx1`, `eps_imesh=0.1`, which was/is the previous default value hard-coded in `./components/cice/src/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90`.   

