### PR TITLE
fixes for ocn_flux_scheme settings of 1 and 2 to work

### DIFF
--- a/cesm/flux_atmocn/shr_flux_mod.F90
+++ b/cesm/flux_atmocn/shr_flux_mod.F90
@@ -142,10 +142,10 @@ contains
        &               evap  ,evap_16O, evap_HDO, evap_18O, &
        &               taux  ,tauy  ,tref  ,qref  ,   &
        &               ocn_surface_flux_scheme, &
-       &               add_gusts, & 
-       &               duu10n, & 
+       &               add_gusts, &
+       &               duu10n, &
        &               ugust_out, &
-       &               u10res, & 
+       &               u10res, &
        &               ustar_sv ,re_sv ,ssq_sv,   &
        &               missval)
 
@@ -267,7 +267,7 @@ contains
     real(R8)    :: tdiff(nMax)               ! tbot - ts
     real(R8)    :: vscl
 
-    real(R8)    :: ugust      ! function: gustiness as a function of convective rainfall.  
+    real(R8)    :: ugust      ! function: gustiness as a function of convective rainfall.
     real(R8)    :: gprec   ! convective rainfall argument for ugust
 
     qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
@@ -346,10 +346,10 @@ contains
           if (mask(n) /= 0) then
 
              !--- compute some needed quantities ---
-             if (add_gusts) then 
+             if (add_gusts) then
                 vmag   = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2 + (1.0_R8*ugust(min(rainc(n),6.94444e-4_r8))**2)) )
                 ugust_out(n) = ugust(min(rainc(n),6.94444e-4_r8))
-             else 
+             else
                 vmag   = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
                 ugust_out(n) = 0.0_r8
              end if
@@ -496,7 +496,7 @@ contains
              qref  (n) = spval  !  2m reference height humidity (kg/kg)
              duu10n(n) = spval  ! 10m wind speed squared (m/s)^2
              ugust_out(n) = spval ! gustiness addition (m/s)
-             u10res(n) = spval ! 10m resolved wind (no gusts) (m/s) 
+             u10res(n) = spval ! 10m resolved wind (no gusts) (m/s)
 
              if (present(ustar_sv)) ustar_sv(n) = spval
              if (present(re_sv   )) re_sv   (n) = spval
@@ -576,6 +576,9 @@ contains
              if (present(re_sv   )) re_sv(n)    = re
              if (present(ssq_sv )) ssq_sv(n) = ssq
 
+             u10res(n) = sqrt(duu10n(n))
+             ugust_out(n) = 0._r8
+
           else
              !------------------------------------------------------------
              ! no valid data here -- out of domain
@@ -592,6 +595,9 @@ contains
              tref     (n) = spval  !  2m reference height temperature (K)
              qref     (n) = spval  !  2m reference height humidity (kg/kg)
              duu10n   (n) = spval  ! 10m wind speed squared (m/s)^2
+
+             u10res   (n) = spval
+             ugust_out(n) = spval
 
              if (present(ustar_sv)) ustar_sv(n) = spval
              if (present(re_sv   )) re_sv   (n) = spval
@@ -611,7 +617,15 @@ contains
                           taux, tauy, tref, qref, &
                           duu10n, ustar_sv, re_sv, ssq_sv, &
                           missval)
-
+       do n=1,nMax
+          if (mask(n) /= 0) then
+             u10res(n) = sqrt(duu10n(n))
+             ugust_out(n) = 0._r8
+          else
+             u10res   (n) = spval
+             ugust_out(n) = spval
+          end if
+       end do
     else
 
        call shr_sys_abort(subName//" subroutine flux_atmOcn requires ocn_surface_flux_scheme = 0, 1 or 2")
@@ -1051,7 +1065,6 @@ contains
           if (present(ssq_sv  )) ssq_sv(n)   = ssq
           if (present(re_sv   )) re_sv(n)    = re
 
-
        else
 
           !------------------------------------------------------------
@@ -1069,6 +1082,7 @@ contains
           tref  (n) = spval  !  2m reference height temperature (K)
           qref  (n) = spval  !  2m reference height humidity (kg/kg)
           duu10n(n) = spval  ! 10m wind speed squared (m/s)^2
+
           ! Optional diagnostics too:
           if (present(ustar_sv)) ustar_sv(n) = spval
           if (present(re_sv   )) re_sv   (n) = spval

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -286,7 +286,7 @@
       <!-- N compsets -->
       <!-- =================================================== -->
       <value compset="_DATM.*_BLOM">24</value>
-      <value compset="_DATM.*_BLOM" grid="o%tnx2">18</value>
+      <value compset="_DATM.*_BLOM" grid="oi%tnx2">18</value>
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
       <!-- =================================================== -->
       <!-- WW3Test compset -->
@@ -334,7 +334,7 @@
     <values match="last">
       <value compset="_MOM6">24</value>
       <value compset="_BLOM">24</value>
-      <value compset="_BLOM" grid="o%tnx2">18</value>
+      <value compset="_BLOM" grid="oi%tnx2">18</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_NEMO">24</value>
     </values>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -286,6 +286,7 @@
       <!-- N compsets -->
       <!-- =================================================== -->
       <value compset="_DATM.*_BLOM">24</value>
+      <value compset="_DATM.*_BLOM" grid="o%tnx2">18</value>
       <value compset="_BLOM" grid="oi%tnx0.25v">48</value>
       <!-- =================================================== -->
       <!-- WW3Test compset -->
@@ -333,6 +334,7 @@
     <values match="last">
       <value compset="_MOM6">24</value>
       <value compset="_BLOM">24</value>
+      <value compset="_BLOM" grid="o%tnx2">18</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_NEMO">24</value>
     </values>
@@ -424,6 +426,8 @@
       <value compset="DATM.+POP\d">TRUE</value>
       <value compset="DATM.+MOM\d">TRUE</value>
       <value compset="DATM.+BLOM\d">TRUE</value>
+      <value compset="DATM%NYF.+BLOM">FALSE</value>
+      <value compset="DATM%IAF.+BLOM">FALSE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
       <value compset="DATM%CPLHIST.+POP\d">FALSE</value>
     </values>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -425,9 +425,9 @@
     <values match="last">
       <value compset="DATM.+POP\d">TRUE</value>
       <value compset="DATM.+MOM\d">TRUE</value>
-      <value compset="DATM.+BLOM\d">TRUE</value>
-      <value compset="DATM%NYF.+BLOM">FALSE</value>
-      <value compset="DATM%IAF.+BLOM">FALSE</value>
+      <value compset="DATM.+BLOM">FALSE</value>
+      <value compset="DATM%NYF.+BLOM">TRUE</value>
+      <value compset="DATM%IAF.+BLOM">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
       <value compset="DATM%CPLHIST.+POP\d">FALSE</value>
     </values>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -932,24 +932,13 @@
       <value>0</value>
     </values>
   </entry>
-  <entry id="gust_fac">
-    <type>real</type>
-    <category>control</category>
-    <group>MED_attributes</group>
-    <desc>
-      wind gustiness factor
-    </desc>
-    <values>
-      <value>0.0D0</value>
-    </values>
-  </entry>
-
   <entry id="add_gusts">
     <type>logical</type>
     <category>control</category>
     <group>MED_attributes</group>
     <desc>
-      add a wind gustiness factor
+      Add a wind gustiness factor. This should be false for
+      ocn_surface_flux_scheme settings of 1 or 2.
     </desc>
     <values>
       <value CAMDEV="True">.true.</value>


### PR DESCRIPTION
### Description of changes
This PR is needed if `ocn_flux_scheme` in nuopc.runconfig is set to either 1 or 2. The default is 0.
In addition - the nuopc.runconfig variable `add_gusts=.false.` when `ocn_flux_scheme=1 `or `ocn_flux_scheme=2`.

Also addresses that CORE forcing for BLOM should always have CPL_ALBAV to be TRUE and that for tnx2v1 - the OCN_NCPL, ATM_NCPL should be 18.

### Specific notes

Contributors other than yourself, if any:  @adamrher

CMEPS Issues Fixed: #33 
Also see https://github.com/NorESMhub/noresm3_dev_simulations/discussions/139
Also see https://github.com/NorESMhub/NorESM/issues/682

For BLOM - also see https://github.com/NorESMhub/BLOM/issues/587.

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? No

### Testing performed
Using noresm3_0_alpha03d - 

./create_newcase --case /cluster/home/mvertens/noresm/n1850_ne30pg3_tn14_alpha3d.testCOARE --compset 1850_CAM70%LT%NORESM%CAMoslo_CLM60%FATES_
CICE_BLOM%HYB%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP --res ne30pg3_tn14 --project nn9560k --machine betzy --compiler intel --run-unsupported

With the settings in https://github.com/NorESMhub/noresm3_dev_simulations/issues/138 
and the following in user_nl_cpl
```
ocn_surface_flux_scheme = 1
add_gusts = .false.
```
- U10 in the cam history file looks fine
- So_ugustOut does not appear in the mediator history file now
- no NaN values occurred.

@oyvindseland @adagj @TomasTorsvik @matsbn - until this is merged - please use this branch can be used to determine the effect of using the COARE scheme 

