### PR TITLE
Enable COARE algorithm by default

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -927,9 +927,13 @@
     <group>MED_attributes</group>
     <desc>
       atm/ocn flux calculation scheme
+      0 : LARGE algorithm
+      1 : COARE algorithm
+      2 : UA algorithm
     </desc>
     <values>
       <value>0</value>
+      <value COMP_OCN="blom" COMP_ATM="cam">1</value>
     </values>
   </entry>
   <entry id="add_gusts">


### PR DESCRIPTION
### Description of changes

Select default namelist definitions for `noresm3_0_beta02` fuly coupled compsets:

```
ocn_surface_flux_scheme = 1
```

### Specific notes

Remove the CAMDEV configuration, which set `add_gusts=.true.` as default for CAM70. This is not compatible with the COARE algorithm for ocean surface fluxes.

Contributors other than yourself, if any: @mvdebolskiy 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) YES

Any User Interface Changes (namelist or namelist defaults changes)? YES

### Testing performed
  - prealpha_noresm : 
    - 1 expected FAIL:
        SMS_D_Ld1_P253.ne30pg3_tn05.N1850.betzy_intel.allactive-defaultio
    - DIFF for all tests when compared with reference `noresm3_0_beta01a` baselines


