### PR TITLE
Make rof and ocn coupling periods align for 2 deg ocn

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -335,6 +335,7 @@
       <value compset="_MOM6">24</value>
       <value compset="_BLOM">24</value>
       <value compset="_BLOM" grid="oi%tnx2">18</value>
+      <!-- quick fix for coupled with 2 deg ocn-->
       <value compset="_BLOM.*_MOSART" grid="oi%tnx2">24</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_NEMO">24</value>

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -335,6 +335,7 @@
       <value compset="_MOM6">24</value>
       <value compset="_BLOM">24</value>
       <value compset="_BLOM" grid="oi%tnx2">18</value>
+      <value compset="_BLOM.*_MOSART" grid="oi%tnx2">24</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_NEMO">24</value>
     </values>


### PR DESCRIPTION
With 2 degree blom, OCN_NCPL is set to 18 while ROF_CPL=8 always, when MOSART is on.

