### PR TITLE
fix to enable correct behavior for aux output for noresm ww3

### DIFF
--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2229,7 +2229,7 @@
     <group>MED_attributes</group>
     <values>
       <value>Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
-      <value COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
+      <!-- <value COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value> -->
     </values>
     <desc>Auxiliary mediator wav2med file1 colon delimited output
     fields. NOTE: these are assumed to be time averaged over a day in
@@ -2261,7 +2261,7 @@
     <group>MED_attributes</group>
     <values>
       <value>.false.</value>
-      <value COMP_WAV='ww3'>.true.</value>
+      <!-- <value COMP_WAV='ww3'>.true.</value> -->
     </values>
     <desc>Auxiliary mediator wav2med file1 time averaged flag for file output.
     If this flag is set to .false. only instantaneous output will be created in the auxiliary file.</desc>
@@ -2272,7 +2272,7 @@
     <group>MED_attributes</group>
     <values>
       <value>wav.24h.avg</value>
-      <value COMP_WAV='ww3'>ww3</value>
+      <!-- <value COMP_WAV='ww3'>ww3</value> -->
     </values>
   </entry>
   <entry id="histaux_wav2med_file1_ntperfile">


### PR DESCRIPTION
### Description of changes

Fix for time averaged ww3 output that is relevant for NorESM WW3. This needs to be reconciled with the ESCOMP WW3/CMEPS behavior.

Ran the following case:
```
./create_newcase --case  <your_case> --compset 2000_DATM%JRA_SLND_SICE_SOCN_SROF_SGLC_WW3 --res TL319_ww3a --mach betzy --project <your_project> --run-unsupported
```

This needed the following addition to `modelgrid_aliases_nuopc.xml` which should come in as a separate PR to ccs_config
```
  <model_grid alias="TL319_ww3a" not_compset="_CAM">
     <grid name="atm">TL319</grid>
     <grid name="wav">ww3a</grid>
     <mask>tnx1v4</mask>
  </model_grid>
```
