### PR TITLE
new coupling_mode setting (noresm) and update to ww3 aux files

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: NorESMhub/NorESM
           path: noresm
-	  ref: noresm_develop
+          ref: noresm_develop
       # this cmeps commit
       - name: cmeps checkout
         uses: actions/checkout@v4

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -63,6 +63,8 @@ jobs:
       - run: echo "PyYAML" > requirements.txt
       - name: Install PyYAML
         run: pip install -r requirements.txt
+      - name: Install git-fleximod
+        run: pip install git-fleximod
       # use the latest noresm main
       - name: noresm checkout
         uses: actions/checkout@v4
@@ -82,7 +84,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           pushd noresm
-          ./bin/git-fleximod update cime ccs_config cdeps share mct parallelio
+          git-fleximod update cime ccs_config cdeps share mct parallelio
           cd ccs_config
           git checkout noresm
           cd ../cime
@@ -123,10 +125,10 @@ jobs:
           key: inputdata
 
       - name: Build ParallelIO
-        if: steps.cache-PARALLELIO.outputs.cache-hit != 'true'
+        if: steps.cache-ParallelIO.outputs.cache-hit != 'true'
         uses: NCAR/ParallelIO/.github/actions/parallelio_cmake@b38e34eeb9b75ce81ac94daf7c5245931de00b9d
         with:
-          parallelio_version: ${{ env.ParallelIO_VERSION }}
+          parallelio_version: ${{ env.PARALLELIO_VERSION }}
           enable_fortran: True
           install_prefix: ${GITHUB_WORKSPACE}/pio
 

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -83,9 +83,11 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           pushd noresm
-          ./bin/git-fleximod update cime ccs_config cdeps share mct parallelio -v
+          ./bin/git-fleximod update cime ccs_config cdeps share mct parallelio
           cd ccs_config
+          git checkout noresm
           cd ../cime
+          git checkout noresm
           git status
           if [[ ! -e "${PWD}/.gitmodules.bak" ]]
              then

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           repository: NorESMhub/NorESM
           path: noresm
+	  ref: noresm_develop
       # this cmeps commit
       - name: cmeps checkout
         uses: actions/checkout@v4

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -83,11 +83,9 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           pushd noresm
-          ./bin/git-fleximod update cime ccs_config cdeps share mct parallelio
+          ./bin/git-fleximod update cime ccs_config cdeps share mct parallelio -v
           cd ccs_config
-          git checkout noresm
           cd ../cime
-          git checkout noresm
           git status
           if [[ ! -e "${PWD}/.gitmodules.bak" ]]
              then

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -63,8 +63,6 @@ jobs:
       - run: echo "PyYAML" > requirements.txt
       - name: Install PyYAML
         run: pip install -r requirements.txt
-      - name: Install git-fleximod
-        run: pip install git-fleximod
       # use the latest noresm main
       - name: noresm checkout
         uses: actions/checkout@v4
@@ -84,7 +82,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           pushd noresm
-          git-fleximod update cime ccs_config cdeps share mct parallelio
+          ./bin/git-fleximod update cime ccs_config cdeps share mct parallelio
           cd ccs_config
           git checkout noresm
           cd ../cime

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: NorESMhub/NorESM
           path: noresm
-          ref: noresm_develop
+          ref: cmeps-cime-actions-testing
       # this cmeps commit
       - name: cmeps checkout
         uses: actions/checkout@v4

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -6,9 +6,9 @@ name: scripts regression tests
 # events but only for the main branch
 on:
   push:
-    branches: [ noresm ]
+    branches: [ main ]
   pull_request:
-    branches: [ noresm ]
+    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: NorESMhub/NorESM
           path: noresm
-          ref: cmeps-cime-actions-testing
+          ref: noresm_develop
       # this cmeps commit
       - name: cmeps checkout
         uses: actions/checkout@v4
@@ -178,19 +178,20 @@ jobs:
       # How to download artifacts:
       # https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts
 
-#      - name: Upload test logs
-#        if: ${{ failure() }}
-#        steps:
-#        - name: Tar test logs
-#          run: tar zcf scratch-${{ matrix.python-version }}.tar.gz /home/runner/noresm/scratch
-#        - name: save artifact
-#          uses: actions/upload-artifact@v4
-#          with:
-#            name: test-logs-${{ matrix.python-version }}
-#            path: scratch-${{ matrix.python-version }}.tar.gz
-#            retention-days: 4
+      - name: Upload test logs
+        if: ${{ failure() }}
+        steps:
+        - name: Tar test logs
+          run: tar zcf scratch-${{ matrix.python-version }}.tar.gz /home/runner/noresm/scratch
+        - name: save artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: test-logs-${{ matrix.python-version }}
+            path: scratch-${{ matrix.python-version }}.tar.gz
+            retention-days: 4
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3
+

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -142,7 +142,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     elif case.get_value("RUN_TYPE") == "branch":
         config["run_type"] = "branch"
 
-    if config['COMP_WAV'] == 'ww3' and config['COMP_ICE'] == 'cice':
+    # determine coupling mode
+    config["coupling_mode"] = case.get_value("COUPLING_MODE")
+
+    if config["coupling_mode"] == "cesm" and config['COMP_WAV'] == 'ww3' and config['COMP_ICE'] == 'cice':
         config["wav_ice_coupling"] = "on"
 
     if config["COMP_OCN"] == "blom":

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -37,8 +37,8 @@
 
   <entry id="COUPLING_MODE">
     <type>char</type>
-    <valid_values>cesm</valid_values>
-    <default_value>cesm</default_value>
+    <valid_values>cesm,noresm</valid_values>
+    <default_value>noresm</default_value>
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <desc>coupling mode</desc>

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2217,7 +2217,7 @@
     <group>ALLCOMP_attributes</group>
     <values>
       <value>.false.</value>
-      <value COMP_WAV='ww3'>.true.</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med average history output every day.
     Note that ww3dev will use this configuration variable and send
@@ -2229,7 +2229,7 @@
     <group>MED_attributes</group>
     <values>
       <value>Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
-      <value COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 colon delimited output
     fields. NOTE: these are assumed to be time averaged over a day in
@@ -2261,7 +2261,7 @@
     <group>MED_attributes</group>
     <values>
       <value>.false.</value>
-      <value COMP_WAV='ww3'>.true.</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 time averaged flag for file output.
     If this flag is set to .false. only instantaneous output will be created in the auxiliary file.</desc>
@@ -2272,7 +2272,7 @@
     <group>MED_attributes</group>
     <values>
       <value>wav.24h.avg</value>
-      <value COMP_WAV='ww3'>ww3</value>
+      <value coupling_mode="cesm" COMP_WAV='ww3'>ww3</value>
     </values>
   </entry>
   <entry id="histaux_wav2med_file1_ntperfile">

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -989,16 +989,13 @@
     <group>MED_attributes</group>
     <desc>
       If true, use shr_wv_sat_mod to calculate qsat for atm-ocn flux calculations.
-
       If false, use the older inline calculation of qsat, which uses a different
       formulation.
-
       (Currently only relevant for ocn_surface_flux_scheme = 0 or 1.)
     </desc>
     <values>
-      <!-- Once CIME_MODEL distinguishes between NorESM and CESM, this value will differ
-      between these two. -->
-      <value>.false.</value>
+      <value coupling_mode="noresm">.false.</value>
+      <value coupling_mode="cesm">.true.</value>
     </values>
   </entry>
   <entry id="add_gusts">
@@ -2263,6 +2260,7 @@
     <group>MED_attributes</group>
     <values>
       <value>.false.</value>
+      <value coupling_mode="noresm" COMP_WAV='ww3'>.false.</value>
       <value coupling_mode="cesm" COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 time averaged flag for file output.

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -2217,6 +2217,7 @@
     <group>ALLCOMP_attributes</group>
     <values>
       <value>.false.</value>
+      <value coupling_mode="noresm" COMP_WAV='ww3'>.true.</value>
       <value coupling_mode="cesm" COMP_WAV='ww3'>.true.</value>
     </values>
     <desc>Auxiliary mediator wav2med average history output every day.
@@ -2228,7 +2229,8 @@
     <category>aux_hist</category>
     <group>MED_attributes</group>
     <values>
-      <value>Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
+      <value>""</value>
+      <value coupling_mode="noresm" COMP_WAV="ww3">Sw_hs_avg:Sw_Tm1_avg:Sw_thm_avg:Sw_u_avg:Sw_v_avg:Sw_ustokes_avg:Sw_vstokes_avg:Sw_tusx_avg:Sw_tusy_avg:Sw_thp0_avg:Sw_fp0_avg:Sw_phs0_avg:Sw_phs1_avg:Sw_pdir0_avg:Sw_pdir1_avg:Sw_pTm10_avg:Sw_pTm11_avg</value>
       <value coupling_mode="cesm" COMP_WAV='ww3'>Sw_Hs:Sw_t01:Sw_t0m1:Sw_thm:Sw_lamult:Sw_ustokes:Sw_vstokes</value>
     </values>
     <desc>Auxiliary mediator wav2med file1 colon delimited output

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -2276,11 +2276,22 @@ contains
        call addfld_from(compwav, 'Sw_Tm1_avg')
        call addfld_from(compwav, 'Sw_thm_avg')
        call addfld_from(compwav, 'Sw_thp0_avg')
+       call addfld_from(compwav, 'Sw_faw_avg')
        call addfld_from(compwav, 'Sw_fp0_avg')
        call addfld_from(compwav, 'Sw_u_avg')
        call addfld_from(compwav, 'Sw_v_avg')
+       call addfld_from(compwav, 'Sw_cu_avg')
+       call addfld_from(compwav, 'Sw_cv_avg')
        call addfld_from(compwav, 'Sw_tusx_avg')
        call addfld_from(compwav, 'Sw_tusy_avg')
+       call addfld_from(compwav, 'Sw_lamult_avg')
+       call addfld_from(compwav, 'Sw_charn_avg')
+       call addfld_from(compwav, 'Sw_tm02_avg')
+       call addfld_from(compwav, 'Sw_foc_avg')
+       call addfld_from(compwav, 'Sw_ifrac_avg')
+       call addfld_from(compwav, 'Sw_thick_avg')
+       call addfld_from(compwav, 'Sw_tauicex_avg')
+       call addfld_from(compwav, 'Sw_tauicey_avg')
     end if
 
     !-----------------------------
@@ -2335,7 +2346,7 @@ contains
             call addmap_from(compwav, 'Sw_t0m1', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
             call addmrg_to(compocn, 'Sw_t0m1', mrg_from=compwav, mrg_fld='Sw_t0m1', mrg_type='copy')
          end if
-      end if    
+      end if
       !-----------------------------
       ! to ocn:
       !-----------------------------
@@ -2348,7 +2359,7 @@ contains
             call addmap_from(compwav, 'Sw_t01', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
             call addmrg_to(compocn, 'Sw_t01', mrg_from=compwav, mrg_fld='Sw_t01', mrg_type='copy')
          end if
-      end if      
+      end if
       !-----------------------------
       ! to ocn:
       !-----------------------------
@@ -2361,7 +2372,7 @@ contains
             call addmap_from(compwav, 'Sw_thm', compocn,  mapbilnr_nstod, 'one', wav2ocn_map)
             call addmrg_to(compocn, 'Sw_thm', mrg_from=compwav, mrg_fld='Sw_thm', mrg_type='copy')
          end if
-      end if      
+      end if
       !-----------------------------
       ! to ocn:
       !-----------------------------

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1249,11 +1249,11 @@
        description: Daily averaged swell swh (only needed for med history output)
      #
      - standard_name: Sw_pdir0_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged wind sea swh (only needed for med history output)
      #
      - standard_name: Sw_pdir1_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged swell swh (only needed for med history output)
      #
      - standard_name: Sw_pTm10_avg
@@ -1269,11 +1269,11 @@
        description: Daily averaged mean wave period of the first moment (only needed for med history output)
      #
      - standard_name: Sw_thm_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged mean wave direction (only needed for med history output)
      #
      - standard_name: Sw_thp0_avg
-       canonical_units: degrees
+       canonical_units: radians
        description: Daily averaged peak wave direction (only needed for med history output)
      #
      - standard_name: Sw_fp0_avg

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -1135,78 +1135,6 @@
        canonical_units: 1
        description: ocean import - Langmuir multiplier
      #
-     - standard_name: Sw_Hs
-       canonical_units: m
-       description: ocean import - Significant wave height
-     #
-     - standard_name: Sw_t0m1
-       canonical_units: s
-       description: Wind sea mean wave period (Tm0,-1)
-     #
-     - standard_name: Sw_t01
-       canonical_units: s
-       description: Wind sea mean wave period (Tm0,1)
-     #
-     - standard_name: Sw_thm
-       canonical_units: radians
-       description: Mean wave direction
-     #
-     - standard_name: Sw_Fp
-       canonical_units: 1
-       description: ocean import - Peak wave frequency
-     #
-     - standard_name: Sw_Dp
-       canonical_units: 1
-       description: ocean import - Peak wave direction
-     #
-     - standard_name: Sw_ustokes_wavenumber_1
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift zonal wavenumber 1
-     #
-     - standard_name: Sw_vstokes_wavenumber_1
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift meridional wavenumber 1
-     #
-     - standard_name: Sw_ustokes_wavenumber_2
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift zonal wavenumber 2
-     #
-     - standard_name: Sw_vstokes_wavenumber_2
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift meridional wavenumber 2
-     #
-     - standard_name: Sw_ustokes_wavenumber_3
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift zonal wavenumber 3
-     #
-     - standard_name: Sw_vstokes_wavenumber_3
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift meridional wavenumber 3
-     #
-     - standard_name: Sw_ustokes_wavenumber_4
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift zonal wavenumber 4
-     #
-     - standard_name: Sw_vstokes_wavenumber_4
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift meridional wavenumber 4
-     #
-     - standard_name: Sw_ustokes_wavenumber_5
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift zonal wavenumber 5
-     #
-     - standard_name: Sw_vstokes_wavenumber_5
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift meridional wavenumber 5
-     #
-     - standard_name: Sw_ustokes_wavenumber_6
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift zonal wavenumber 6
-     #
-     - standard_name: Sw_vstokes_wavenumber_6
-       canonical_units: m/s
-       description: ocean import - partitioned Stokes drift meridional wavenumber 6
-     #
      - standard_name: Sw_ustokes
        canonical_units: m/s
        description: ocean import - Stokes drift u component
@@ -1230,68 +1158,113 @@
      #
      - standard_name: Sw_ustokes_avg
        canonical_units: m/s
-       description: Daily averaged stokes drift u component (only needed for med history output)
+       description: Daily averaged stokes drift u component (only needed for mediator history output)
      #
      - standard_name: Sw_vstokes_avg
        canonical_units: m/s
-       description: Daily averaged stokes drift v component (only needed for med history output)
+       description: Daily averaged stokes drift v component (only needed for mediator history output)
      #
      - standard_name: Sw_hs_avg
        canonical_units: m
-       description: Daily averaged significant wave hight (only needed for med history output)
+       description: Daily averaged significant wave hight (only needed for mediator history output)
      #
      - standard_name: Sw_phs0_avg
        canonical_units: m
-       description: Daily averaged averaged wind sea swh (only needed for med history output)
+       description: Daily averaged averaged wind sea swh (only needed for mediator history output)
      #
      - standard_name: Sw_phs1_avg
        canonical_units: m
-       description: Daily averaged swell swh (only needed for med history output)
+       description: Daily averaged swell swh (only needed for mediator history output)
      #
      - standard_name: Sw_pdir0_avg
        canonical_units: radians
-       description: Daily averaged wind sea swh (only needed for med history output)
+       description: Daily averaged wind sea swh (only needed for mediator history output)
      #
      - standard_name: Sw_pdir1_avg
        canonical_units: radians
-       description: Daily averaged swell swh (only needed for med history output)
+       description: Daily averaged swell swh (only needed for mediator history output)
      #
      - standard_name: Sw_pTm10_avg
        canonical_units: s
-       description: Daily averaged wind sea mean wave Tm1 period (only needed for med history output)
+       description: Daily averaged wind sea mean wave Tm1 period (only needed for mediator history output)
      #
      - standard_name: Sw_pTm11_avg
        canonical_units: s
-       description: Daily average swell mean wave Tm1 period (only needed for med history output)
+       description: Daily average swell mean wave Tm1 period (only needed for mediator history output)
      #
      - standard_name: Sw_Tm1_avg
        canonical_units: s
-       description: Daily averaged mean wave period of the first moment (only needed for med history output)
+       description: Daily averaged mean wave period of the first moment (only needed for mediator history output)
      #
      - standard_name: Sw_thm_avg
        canonical_units: radians
-       description: Daily averaged mean wave direction (only needed for med history output)
+       description: Daily averaged mean wave direction (only needed for mediator history output)
      #
      - standard_name: Sw_thp0_avg
        canonical_units: radians
-       description: Daily averaged peak wave direction (only needed for med history output)
+       description: Daily averaged peak wave direction (only needed for mediator history output)
      #
      - standard_name: Sw_fp0_avg
        canonical_units: 1/s
-       description: Daily averaged peak wave frequency (only needed for med history output)
+       description: Daily averaged peak wave frequency (only needed for mediator history output)
      #
      - standard_name: Sw_u_avg
        canonical_units: m/s
-       description: Daily averaged surface wind zonal (only needed for med history output)
+       description: Daily averaged surface wind zonal (only needed for mediator history output)
      #
      - standard_name: Sw_v_avg
        canonical_units: m/s
-       description: Daily averaged surface wind meridional (only needed for med history output)
+       description: Daily averaged surface wind meridional (only needed for mediator history output)
+     #
+     - standard_name: Sw_cu_avg
+       canonical_units: m/s
+       description: Daily averaged surface zonal current(only needed for mediator history output)
+     #
+     - standard_name: Sw_cv_avg
+       canonical_units: m/s
+       description: Daily averaged surface meridional current (only needed for mediator history output)
      #
      - standard_name: Sw_tusx_avg
        canonical_units: m2/s
-       description: Daily averaged stokes zonal transport vector (only needed for med history output)
+       description: Daily averaged stokes zonal transport vector (only needed for mediator history output)
      #
      - standard_name: Sw_tusy_avg
        canonical_units: m2/s
-       description: Daily averaged stokes meridional transport vector (only needed for med history output)
+       description: Daily averaged stokes meridional transport vector (only needed for mediator history output)
+      #
+     - standard_name: Sw_lamult_avg
+       canonical_units: 1
+       description: Daily averaged Langmuir number (only needed for mediator history output)
+      #
+     - standard_name: Sw_charn_avg
+       canonical_units: 1
+       description: Daily averaged Charnock parameter (only needed for mediator history output)
+     #
+     - standard_name: Sw_tm02_avg
+       canonical_units: s
+       alias: Total_m2-period
+       description: Daily averaged mean wave period of the second moment (only needed for mediator history output)
+     #
+     - standard_name: Sw_foc_avg
+       canonical_units: W/m3
+       description: Daily averaged wave to ocean energy flux (only needed for mediator history output)
+     #
+     - standard_name: Sw_faw_avg
+       canonical_units: W/m3
+       description: Daily averaged wind to wave energy flux (only needed for mediator history output)
+     #
+     - standard_name: Sw_ifrac_avg
+       canonical_units: 1
+       description: Daily averaged sea ice concentration  (only needed for mediator history output)
+     #
+     - standard_name: Sw_thick_avg
+       canonical_units: m
+       description: Daily averaged sea ice thickness (only needed for mediator history output)
+     #
+     - standard_name: Sw_tauicex_avg
+       canonical_units: m2/s2
+       description: Daily averaged x component of momentum flux to sea ice  (only needed for mediator history output)
+     #
+     - standard_name: Sw_tauicey_avg
+       canonical_units: m2/s2
+       description: Daily averaged y component of momentum flux to sea ice (only needed for mediator history output)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -832,7 +832,7 @@ contains
     ! advertise phase
     call med_fldlist_init1(ncomps)
 
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        call esmFldsExchange_cesm(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (coupling_mode(1:3) == 'ufs') then
@@ -1849,7 +1849,7 @@ contains
       ! Initialize memory for fldlistFr(:)%flds(:) and fldlistTo(:)%flds(:) - this is needed for
       ! call below for the initialize phase
 
-      if (trim(coupling_mode) == 'cesm') then
+      if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
          call esmFldsExchange_cesm(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       else if (coupling_mode(1:3) == 'ufs') then

--- a/mediator/med_internalstate_mod.F90
+++ b/mediator/med_internalstate_mod.F90
@@ -47,7 +47,8 @@ module med_internalstate_mod
   character(len=CS), public :: glc_name = ''
 
   ! Coupling mode
-  character(len=CS), public :: coupling_mode ! valid values are [cesm,ufs.nfrac,ufs.frac,ufs.nfrac.aoflux,ufs.frac.aoflux,hafs,hafs.mom6]
+  ! valid values are [cesm,noresm,ufs.nfrac,ufs.frac,ufs.nfrac.aoflux,ufs.frac.aoflux,hafs,hafs.mom6]
+  character(len=CS), public :: coupling_mode
 
   ! Atmosphere-ocean flux algorithm
   character(len=CS), public :: aoflux_code   ! valid values are [cesm,ccpp]
@@ -695,7 +696,7 @@ contains
     if ( trim(coupling_mode) == 'hafs') then  ! not hafs.mom6
        if (is_local%wrap%comp_present(compatm)) defaultMasks(compatm,1) = 1
     endif
-    if ( coupling_mode /= 'cesm') then
+    if ( trim(coupling_mode) /= 'cesm' .and. trim(coupling_mode) /= 'noresm' ) then
        if (is_local%wrap%comp_present(compatm) .and. atm_name(1:4) == 'datm') then
           defaultMasks(compatm,1) = 0
        end if

--- a/mediator/med_map_mod.F90
+++ b/mediator/med_map_mod.F90
@@ -415,7 +415,7 @@ contains
     dstMaskValue = defaultMasks(n2,2)
 
     ! override defaults for specific cases
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        if (n1 == compwav .and. n2 == compocn) then
          srcMaskValue = 0
          dstMaskValue = ispval_mask
@@ -441,7 +441,7 @@ contains
     call ESMF_LogWrite(trim(string), ESMF_LOGMSG_INFO)
 
     polemethod=ESMF_POLEMETHOD_ALLAVG
-    if (trim(coupling_mode) == 'cesm' .or. coupling_mode(1:3) == 'ufs') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm' .or. coupling_mode(1:3) == 'ufs') then
        if (n1 == compwav .or. n2 == compwav) then
          polemethod = ESMF_POLEMETHOD_NONE ! todo: remove this when ESMF tripolar mapping fix is in place.
        endif

--- a/mediator/med_phases_aofluxes_mod.F90
+++ b/mediator/med_phases_aofluxes_mod.F90
@@ -904,7 +904,7 @@ contains
     call ESMF_FieldRegridStore(xgrid, field_a, field_x, routehandle=rh_agrid2xgrid_2ndord, &
          regridmethod=ESMF_REGRIDMETHOD_CONSERVE_2ND, srcTermProcessing=srcTermProcessing_Value, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        call ESMF_FieldRegridStore(field_a, field_x, routehandle=rh_agrid2xgrid_bilinr, &
             regridmethod=ESMF_REGRIDMETHOD_BILINEAR, dstMaskValues=(/0/), &
             srcTermProcessing=srcTermProcessing_Value, rc=rc)
@@ -1302,7 +1302,7 @@ contains
 
        ! Map atm->xgrid
        if (trim(fldnames_atm_in(nf)) == 'Sa_u' .or. (trim(fldnames_atm_in(nf)) == 'Sa_v')) then
-          if (trim(coupling_mode) == 'cesm') then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
              call ESMF_FieldRegrid(field_src, field_dst, routehandle=rh_agrid2xgrid_patch, &
                   termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
           else
@@ -1311,7 +1311,7 @@ contains
           end if
           if (chkerr(rc,__LINE__,u_FILE_u)) return
        else
-          if (trim(coupling_mode) == 'cesm') then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
              call ESMF_FieldRegrid(field_src, field_dst, routehandle=rh_agrid2xgrid_bilinr, &
                   termorderflag=ESMF_TERMORDER_SRCSEQ, zeroregion=ESMF_REGION_TOTAL, rc=rc)
           else
@@ -1656,12 +1656,12 @@ end subroutine med_aofluxes_map_ogrid2xgrid_input
     end if
 
     ! The following conditional captures the cases where aoflux_in%psfc is needed in calls
-    ! to flux_atmocn / flux_atmocn_ccpp. Note that coupling_mode=='cesm' is equivalent to
+    ! to flux_atmocn / flux_atmocn_ccpp. Note that coupling_mode==['cesm','noresm] is equivalent to
     ! the CESMCOUPLED CPP token, and coupling_mode(1:3)=='ufs' is roughly equivalent to
     ! the UFS_AOFLUX CPP token (noting that we should only be in this subroutine if using
     ! one of the aoflux variants of the ufs coupling_mode).
-    if ((trim(coupling_mode) == 'cesm') .or. &
-         (coupling_mode(1:3) == 'ufs' .and. trim(aoflux_code) == 'ccpp')) then
+    if ( (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') .or. &
+         (coupling_mode(1:3) == 'ufs' .and. trim(aoflux_code) == 'ccpp') ) then
        call fldbun_getfldptr(fldbun_a, 'Sa_pslv', aoflux_in%psfc, xgrid=xgrid, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -5,6 +5,7 @@ module med_phases_history_mod
   !-----------------------------------------------------------------------------
 
   use med_kind_mod          , only : CX=>SHR_KIND_CX, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, R8=>SHR_KIND_R8
+  use med_kind_mod          , only : CXX=>SHR_KIND_CXX
   use ESMF                  , only : ESMF_GridComp, ESMF_GridCompGet, ESMF_VM
   use ESMF                  , only : ESMF_Clock, ESMF_ClockGet, ESMF_ClockSet, ESMF_ClockAdvance
   use ESMF                  , only : ESMF_ClockGetNextTime, ESMF_ClockGetAlarm, ESMF_ClockIsCreated
@@ -1092,7 +1093,7 @@ contains
     integer                 :: n,n1,nf
     character(CL)           :: prefix
     character(CL)           :: cvalue
-    character(CL)           :: auxflds
+    character(CXX)          :: auxflds
     integer                 :: fieldCount
     logical                 :: found
     logical                 :: enable_auxfile

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -106,7 +106,7 @@ contains
     !---------------------------------------
     !--- map ocean albedos from ocn to atm grid if appropriate
     !---------------------------------------
-    if (trim(coupling_mode) == 'cesm') then
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
        call med_map_field_packed( &
             FBSrc=is_local%wrap%FBMed_ocnalb_o, &
             FBDst=is_local%wrap%FBMed_ocnalb_a, &
@@ -120,7 +120,7 @@ contains
     !---------------------------------------
     !--- map atm/ocn fluxes from ocn to atm grid if appropriate
     !---------------------------------------
-    if (trim(coupling_mode) == 'cesm' .or. &
+    if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm' .or. &
          trim(coupling_mode) == 'ufs.frac.aoflux') then
        if (is_local%wrap%aoflux_grid == 'ogrid') then
           call med_aofluxes_map_ogrid2agrid_output(gcomp, rc)

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -87,7 +87,8 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Apply precipitation factor from ocean (that scales atm rain and snow to ice) if appropriate
-    if (trim(coupling_mode) == 'cesm' .and. is_local%wrap%flds_scalar_index_precip_factor /= 0) then
+    if ( (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') .and. &
+         is_local%wrap%flds_scalar_index_precip_factor /= 0) then
 
        ! Note that in med_internal_mod.F90 all is_local%wrap%flds_scalar_index_precip_factor
        ! is initialized to 0.

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -634,7 +634,7 @@ contains
        end do
        ! Compute sw export to ocean bands if required
        if (export_swnet_by_bands) then
-          if (trim(coupling_mode) == 'cesm') then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode == 'noresm')) then
              c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
              Foxx_swnet_vdr(:) = c1 * Foxx_swnet(:)
              Foxx_swnet_vdf(:) = c2 * Foxx_swnet(:)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -634,7 +634,7 @@ contains
        end do
        ! Compute sw export to ocean bands if required
        if (export_swnet_by_bands) then
-          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode == 'noresm')) then
+          if (trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') then
              c1 = 0.285; c2 = 0.285; c3 = 0.215; c4 = 0.215
              Foxx_swnet_vdr(:) = c1 * Foxx_swnet(:)
              Foxx_swnet_vdf(:) = c2 * Foxx_swnet(:)
@@ -755,7 +755,8 @@ contains
     end if
 
     ! Apply precipitation factor from ocean (that scales atm rain and snow back to ocn ) if appropriate
-    if (trim(coupling_mode) == 'cesm' .and. is_local%wrap%flds_scalar_index_precip_factor /= 0) then
+    if ((trim(coupling_mode) == 'cesm' .or. trim(coupling_mode) == 'noresm') .and. &
+         is_local%wrap%flds_scalar_index_precip_factor /= 0) then
 
        ! Note that in med_internal_mod.F90 all is_local%wrap%flds_scalar_index_precip_factor
        ! is initialized to 0.


### PR DESCRIPTION
### Description of changes
This PR adds a new valid value - `noresm` -  to the xml variable` coupling_mode` that can then be used to have different default behavior for auxiliary ww3 averaging output variables in cmeps.
In addition - new variables from ww3 were also added to esmFldsExchange_cesm_mod.F90 and fd_cesm.yaml

### Specific notes
Because `coupling_mode` can now be either `cesm` or `noresm` the code needed to be extended to recognize the new `noresm` setting and perform the same behavior as for the `cesm` setting.

Contributors other than yourself, if any: None

CMEPS Issues Fixed: None

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? aux_

### Testing performed
using noresm3_0_beta17 with the following code changes:
- https://github.com/NorESMhub/NorESM/pull/807
- https://github.com/NorESMhub/ccs_config_noresm/pull/89
- https://github.com/NorESMhub/WW3/pull/21

compared to noresm3_0_beta16:
prealpha_noresm - PASS, new BFAIL tests due to new grid aliases for active CISM compsets
aux_cam_noresm - PASS
aux_blom_noresm - PASS

This will not effect any CTSM compsets