### PR TITLE
merge to ESCOMP cmeps1.1.48

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -2,13 +2,11 @@
 
 name: scripts regression tests
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
+# Controls when the action will run. Only runs when manually triggered. (See
+# https://github.com/escomp/cmeps/issues/646 for discussion regarding why we don't run
+# this automatically.)
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -176,17 +176,17 @@ jobs:
       # How to download artifacts:
       # https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts
 
-      - name: Upload test logs
-        if: ${{ failure() }}
-        steps:
-        - name: Tar test logs
-          run: tar zcf scratch-${{ matrix.python-version }}.tar.gz /home/runner/noresm/scratch
-        - name: save artifact
-          uses: actions/upload-artifact@v4
-          with:
-            name: test-logs-${{ matrix.python-version }}
-            path: scratch-${{ matrix.python-version }}.tar.gz
-            retention-days: 4
+      # - name: Upload test logs
+      #   if: ${{ failure() }}
+      #   steps:
+      #   - name: Tar test logs
+      #     run: tar zcf scratch-${{ matrix.python-version }}.tar.gz /home/runner/noresm/scratch
+      #   - name: save artifact
+      #     uses: actions/upload-artifact@v4
+      #     with:
+      #       name: test-logs-${{ matrix.python-version }}
+      #       path: scratch-${{ matrix.python-version }}.tar.gz
+      #       retention-days: 4
 #     the following can be used by developers to login to the github server in case of errors
 #     see https://github.com/marketplace/actions/debugging-with-tmate for further details
 #      - name: Setup tmate session

--- a/cesm/driver/esm.F90
+++ b/cesm/driver/esm.F90
@@ -401,6 +401,7 @@ contains
     use shr_wv_sat_mod   , only : shr_wv_sat_make_tables, ShrWVSatTableSpec
     use shr_wv_sat_mod   , only : shr_wv_sat_get_scheme_idx, shr_wv_sat_valid_idx
     use glc_elevclass_mod, only : glc_elevclass_init
+    use shr_wtracers_mod , only : shr_wtracers_init
    !use shr_scam_mod     , only : shr_scam_checkSurface
 
     ! input/output variables
@@ -543,6 +544,13 @@ contains
        mixed_spec  = ShrWVSatTableSpec(ceiling(250._R8/wv_sat_table_spacing), 125._R8, wv_sat_table_spacing)
        call shr_wv_sat_make_tables(liquid_spec, ice_spec, mixed_spec)
     end if
+
+    !----------------------------------------------------------
+    ! Initialize water tracer info
+    !----------------------------------------------------------
+
+    call shr_wtracers_init(driver, maintask, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
   end subroutine InitAttributes
 

--- a/cesm/share_wrappers/wtracers_mod.F90
+++ b/cesm/share_wrappers/wtracers_mod.F90
@@ -4,15 +4,30 @@ module wtracers_mod
    ! This module wraps shr_wtracers_mod from the CESM_share repository to avoid direct
    ! dependencies on this share code from CMEPS.
    !
+   ! It is acceptable for CESM-specific CMEPS code (e.g., in the cesm directory) to call
+   ! directly into shr_wtracers_mod, but CMEPS code shared between CESM and other modeling
+   ! systems (e.g., UFS) should go through this module.
+   !
    ! See also the version of wtracers_mod in the ufs directory for when we do not have
    ! access to the CESM_share library.
    !-----------------------------------------------------------------------------
 
-   use shr_wtracers_mod, only : wtracers_is_wtracer_field => shr_wtracers_is_wtracer_field
+   use shr_wtracers_mod, only : wtracers_present             => shr_wtracers_present
+   use shr_wtracers_mod, only : wtracers_get_num_tracers     => shr_wtracers_get_num_tracers
+   use shr_wtracers_mod, only : wtracers_is_wtracer_field    => shr_wtracers_is_wtracer_field
+   use shr_wtracers_mod, only : wtracers_get_bulk_fieldname  => shr_wtracers_get_bulk_fieldname
+   use shr_wtracers_mod, only : wtracers_check_tracer_ratios => shr_wtracers_check_tracer_ratios
+   use shr_wtracers_mod, only : WTRACERS_SUFFIX
 
    implicit none
    private
 
-   public :: wtracers_is_wtracer_field  ! return true if the given field name is a water tracer field
+   public :: wtracers_present             ! return true if there are water tracers in this simulation
+   public :: wtracers_get_num_tracers     ! get number of water tracers in this simulation
+   public :: wtracers_is_wtracer_field    ! return true if the given field name is a water tracer field
+   public :: wtracers_get_bulk_fieldname  ! return the name of the equivalent bulk field corresponding to a water tracer field
+   public :: wtracers_check_tracer_ratios ! check tracer ratios against expectations
+
+   public :: WTRACERS_SUFFIX ! suffix for water tracer field names
 
 end module wtracers_mod

--- a/cime_config/buildexe
+++ b/cime_config/buildexe
@@ -64,10 +64,10 @@ def _main_func():
         skip_mediator = False
 
     if ocn_model == 'mom':
-        gmake_args += "USE_FMS=TRUE"
+        gmake_args += " USE_FMS=TRUE"
 
     if link_libs is not None:
-        gmake_args += 'USER_SLIBS="{}"'.format(link_libs)
+        gmake_args += ' USER_SLIBS="{}"'.format(link_libs)
 
     comp_classes = case.get_values("COMP_CLASSES")
     for comp in comp_classes:

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -344,6 +344,11 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     # End if pause is active
 
     # --------------------------------
+    # Overwrite: set water tracers
+    # --------------------------------
+    _add_water_tracers(case.get_value("WATER_TRACERS"), nmlgen)
+
+    # --------------------------------
     # Specify input data list file
     # --------------------------------
     data_list_path = os.path.join(
@@ -611,6 +616,44 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             print(   "histaux_lnd2med_file2_flds = \'Flrl_rofsur:Flrl_rofi:Flrl_rofgwl:Flrl_rofsub:Flrl_rofsur_nonh2o\'\n")
             with open(user_nl_cpl, 'a') as user_file:
                 user_file.write("histaux_lnd2med_file2_flds = \'Flrl_rofsur:Flrl_rofi:Flrl_rofgwl:Flrl_rofsub:Flrl_rofsur_nonh2o\'\n")
+
+###############################################################################
+def _add_water_tracers(water_tracers_xml, nmlgen):
+    ###############################################################################
+
+    if not water_tracers_xml.strip():
+        water_tracers = []
+    else:
+        water_tracers = water_tracers_xml.split(":")
+    tracer_names = []
+    tracer_species = []
+    tracer_initial_ratios = []
+
+    for tracer in water_tracers:
+        # Each item in the list consists of a name and then, optionally, a '%' followed by
+        # the isotope species for this tracer. For standard water tracers (i.e., tracers
+        # of bulk water), the list item will only contain the name (without a '%').
+        expect(
+            tracer.count("%") <= 1,
+            f"Invalid WATER_TRACERS element, '{tracer}': Each element of WATER_TRACERS must contain at most 1 '%' separator",
+        )
+        parts = tracer.split("%")
+        tracer_names.append(parts[0])
+        if len(parts) > 1:
+            tracer_species.append(parts[1])
+            # We could check the validity of the species name here (confirming that it's
+            # one of the handled species), but that would lead to this allowed list being
+            # replicated in multiple places (here as well as in the Fortran), which would
+            # make it more difficult to add new species later. So we're deferring this
+            # check to runtime.
+        else:
+            tracer_species.append("-")
+        tracer_initial_ratios.append("1.0")
+
+    nmlgen.add_default("water_tracer_names", ":".join(tracer_names))
+    nmlgen.add_default("water_tracer_species", ":".join(tracer_species))
+    nmlgen.add_default("water_tracer_initial_ratios", ":".join(tracer_initial_ratios))
+
 
 ###############################################################################
 def _create_runseq(case, coupling_times, valid_comps):

--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -511,7 +511,7 @@
   </entry>
 
   <!-- ===================================================================== -->
-  <!-- averaged history frequencies -->
+  <!-- controls over various other options -->
   <!-- ===================================================================== -->
 
   <entry id="BUDGETS">
@@ -589,6 +589,31 @@
     <group>run_physics</group>
     <file>env_run.xml</file>
     <desc>Freezing point calculation for salt water.</desc>
+  </entry>
+
+  <entry id="WATER_TRACERS">
+   <type>char</type>
+   <default_value></default_value>
+   <group>run_coupling</group>
+   <file>env_run.xml</file>
+   <desc>
+      Colon-delimited list of water tracers enabled in this run.
+
+      Each item in the list consists of a name and then, optionally, a '%' followed by the
+      isotope species for this tracer. For standard water tracers (i.e., tracers of bulk
+      water), the list item will only contain the name (without a '%'). The name can be
+      anything; if an isotope species is specified, it must match one of the implemented
+      water isotopes: H218O, H217O or HDO. By convention, a tracer that is the full
+      quantity of a given isotope will have a name that is identical to the species (e.g.,
+      H218O:H218O).
+
+      For example, this list could be:
+      MyRegularTracer:HDO%HDO:H218O%H218O:SomeOtherTracer:MyHdoTracer%HDO:YetAnotherTracer
+
+      This specifies three standard (bulk water) tracers (MyRegularTracer, SomeOtherTracer
+      and YetAnotherTracer), two isotopes (HDO and H218O), and a tracer that is a subset
+      of HDO (MyHdoTracer). (Note that the ordering in the list is not important.)
+   </desc>
   </entry>
 
 

--- a/cime_config/namelist_definition_drv.xml
+++ b/cime_config/namelist_definition_drv.xml
@@ -874,7 +874,6 @@
     </desc>
     <values>
       <value>on</value>
-      <value COMP_LND="xlnd">off</value>
     </values>
   </entry>
   <entry id="remove_negative_runoff_lnd">
@@ -2282,6 +2281,10 @@
     <desc>Number of time samples per file.</desc>
     <values>
       <value>30</value>
+      <!-- Generate daily WW3 hist files for ERS/ERI tests to prevent mismatched filenames
+        and contents between initial and restart runs.-->
+      <value TESTCASE='ERS'>1</value>
+      <value TESTCASE='ERI'>1</value>
     </values>
   </entry>
 
@@ -2632,18 +2635,6 @@
     </values>
   </entry>
 
-  <entry  id="flds_wiso" modify_via_xml="FLDS_WISO">
-    <type>logical</type>
-    <category>flds</category>
-    <group>ALLCOMP_attributes</group>
-    <desc>
-      Pass water isotopes between components
-    </desc>
-    <values>
-      <value>.false.</value>
-    </values>
-  </entry>
-
   <entry id="flds_r2l_stream_channel_depths">
     <type>logical</type>
     <category>flds</category>
@@ -2692,6 +2683,66 @@
      <value>.false.</value>
      <value COMP_GLC="cism">$CISM_EVOLVE</value>
     </values>
+  </entry>
+
+  <entry id="water_tracer_names" modify_via_xml="WATER_TRACERS" skip_default_entry="true">
+   <type>char</type>
+   <category>water_tracers</category>
+   <group>ALLCOMP_attributes</group>
+   <desc>
+      Colon-delimited list of names of water tracers in this run.
+   </desc>
+   <values>
+      <value></value>
+   </values>
+  </entry>
+
+  <entry id="water_tracer_species" modify_via_xml="WATER_TRACERS" skip_default_entry="true">
+   <type>char</type>
+   <category>water_tracers</category>
+   <group>ALLCOMP_attributes</group>
+   <desc>
+      Colon-delimited list of species of water tracers in this run.
+
+      Each element in the list corresponds to an element in water_tracer_names. A value of
+      '-' for a given element indicates a standard water tracer (i.e., a tracer of bulk
+      water).
+   </desc>
+   <values>
+      <value></value>
+   </values>
+  </entry>
+
+  <entry id="water_tracer_initial_ratios" skip_default_entry="true">
+   <type>char</type>
+   <category>water_tracers</category>
+   <group>ALLCOMP_attributes</group>
+   <desc>
+      Colon-delimited list of initial water tracer ratios (as a fraction of total water).
+
+      Each element in the list corresponds to an element in water_tracer_names.
+
+      For water isotopes, this ratio is typically set to 1 for numerical reasons; the
+      actual isotopic ratios can then be determined via reference to standard global
+      ratios.
+   </desc>
+   <values>
+      <value></value>
+   </values>
+  </entry>
+
+  <entry id="water_tracers_do_checks">
+   <type>logical</type>
+   <category>water_tracers</category>
+   <group>ALLCOMP_attributes</group>
+   <desc>
+      Check consistency between water tracer fields and their corresponding bulk fields.
+
+      This should only be used with artificial tracers that maintain a fixed ratio.
+   </desc>
+   <values>
+      <value>.false.</value>
+   </values>
   </entry>
 
   <!-- =========================== -->

--- a/cime_config/testdefs/testlist_drv.xml
+++ b/cime_config/testdefs/testlist_drv.xml
@@ -247,6 +247,17 @@
     </options>
   </test>
 
+  <test compset="X" grid="f19_g17" name="SMS_D_Ld2" testmods="drv/water_tracers--drv/glc_avg_frequently">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cmeps"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+      <option name="comment">Test handling of water tracers in CMEPS; includes glc_avg_frequently testmod to exercise the lnd-to-glc mapping.</option>
+    </options>
+  </test>
+
   <!-- ======================================= -->
   <!-- TG compsets -->
   <!-- ======================================= -->

--- a/cime_config/testdefs/testmods_dirs/drv/glc_avg_frequently/README
+++ b/cime_config/testdefs/testmods_dirs/drv/glc_avg_frequently/README
@@ -1,0 +1,2 @@
+This testmod turns on more frequent averaging of the fields sent to glc so that the
+mapping of these fields can be tested in a run shorter than a year.

--- a/cime_config/testdefs/testmods_dirs/drv/glc_avg_frequently/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/drv/glc_avg_frequently/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange GLC_AVG_PERIOD=glc_coupling_period

--- a/cime_config/testdefs/testmods_dirs/drv/water_tracers/README
+++ b/cime_config/testdefs/testmods_dirs/drv/water_tracers/README
@@ -1,0 +1,3 @@
+This testmod turns on multiple water tracers along with checks to ensure that they
+maintain their correct ratio over time. (These checks will only pass if the water tracers
+used in the test do not invoke any physics that would cause a change in their ratios.)

--- a/cime_config/testdefs/testmods_dirs/drv/water_tracers/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/drv/water_tracers/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange WATER_TRACERS=tracer1:tracer2

--- a/cime_config/testdefs/testmods_dirs/drv/water_tracers/user_nl_cpl
+++ b/cime_config/testdefs/testmods_dirs/drv/water_tracers/user_nl_cpl
@@ -1,0 +1,2 @@
+water_tracer_initial_ratios = "0.1:2"
+water_tracers_do_checks = .true.

--- a/med_test_comps/xatm/src/atm_comp_nuopc.F90
+++ b/med_test_comps/xatm/src/atm_comp_nuopc.F90
@@ -15,10 +15,13 @@ module atm_comp_nuopc
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
+  use shr_wtracers_mod , only : WTRACERS_SUFFIX
+  use shr_wtracers_mod , only : shr_wtracers_present, shr_wtracers_get_num_tracers
   use dead_methods_mod  , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod    , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod    , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -39,7 +42,6 @@ module atm_comp_nuopc
   integer                :: fldsFrAtm_num = 0
   type (fld_list_type)   :: fldsToAtm(fldsMax)
   type (fld_list_type)   :: fldsFrAtm(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
 
   type(ESMF_Mesh)        :: mesh
   integer                :: nxg         ! global dim i-direction
@@ -121,6 +123,8 @@ contains
     character(CL)     :: cvalue
     character(len=CL) :: logmsg
     logical           :: isPresent, isSet
+    logical           :: has_wtracers
+    integer           :: num_wtracers
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -202,6 +206,9 @@ contains
 
     if (nxg /= 0 .and. nyg /= 0) then
 
+       has_wtracers = shr_wtracers_present()
+       num_wtracers = shr_wtracers_get_num_tracers()
+
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, trim(flds_scalar_name))
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_topo'       )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_z'          )
@@ -210,6 +217,10 @@ contains
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_tbot'       )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_ptem'       )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_shum'       )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_shum'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_pbot'       )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_dens'       )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Sa_pslv'       )
@@ -217,6 +228,16 @@ contains
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_rainl'    )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_snowc'    )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_snowl'    )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_rainc'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_rainl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_snowc'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_snowl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_lwdn'     )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swndr'    )
        call fld_list_add(fldsFrAtm_num, fldsFrAtm, 'Faxa_swvdr'    )
@@ -238,6 +259,10 @@ contains
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'So_ofrac'  )
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_tref'   )
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_qref'   )
+       if (has_wtracers) then
+          call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_qref'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sx_t'      )
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'So_t'      )
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Sl_fv'     )
@@ -253,6 +278,10 @@ contains
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_sen'  )
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_lwup' )
        call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_evap' )
+       if (has_wtracers) then
+          call fld_list_add(fldsToAtm_num, fldsToAtm, 'Faxx_evap'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
 
        do n = 1,fldsFrAtm_num
           if(mastertask) write(logunit,*)'Advertising From Xatm ',trim(fldsFrAtm(n)%stdname)
@@ -417,7 +446,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer           :: n, nf, nind
+    integer           :: n
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -440,19 +469,16 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    ! Start from index 2 in order to Skip the scalar field here
-    do nf = 2,fldsFrAtm_num
-       if (fldsFrAtm(nf)%ungridded_ubound == 0) then
-          call field_setexport(exportState, trim(fldsFrAtm(nf)%stdname), lon, lat, nf=nf, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          do nind = 1,fldsFrAtm(nf)%ungridded_ubound
-             call field_setexport(exportState, trim(fldsFrAtm(nf)%stdname), lon, lat, nf=nf+nind-1, &
-                  ungridded_index=nind, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          end do
-       end if
-    end do
+    call set_all_export_fields( &
+         exportState = exportState, &
+         flds = fldsFrAtm, &
+         fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+         fld_max = fldsFrAtm_num, &
+         lon = lon, &
+         lat = lat, &
+         field_setexport = field_setexport, &
+         rc = rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(lon)
     deallocate(lat)
@@ -478,6 +504,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/med_test_comps/xglc/src/glc_comp_nuopc.F90
+++ b/med_test_comps/xglc/src/glc_comp_nuopc.F90
@@ -15,10 +15,13 @@ module glc_comp_nuopc
   use shr_sys_mod      , only : shr_sys_abort
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_log_mod     , only : shr_log_getlogunit, shr_log_setlogunit
+  use shr_wtracers_mod, only : WTRACERS_SUFFIX
+  use shr_wtracers_mod, only : shr_wtracers_present, shr_wtracers_get_num_tracers
   use dead_methods_mod , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod   , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod   , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod   , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -38,7 +41,6 @@ module glc_comp_nuopc
   integer                :: fldsFrGlc_num = 0
   type (fld_list_type)   :: fldsToGlc(fldsMax)
   type (fld_list_type)   :: fldsFrGlc(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
 
   type(ESMF_Mesh)        :: mesh
   integer                :: nxg                  ! global dim i-direction
@@ -128,6 +130,8 @@ contains
     character(len=CL) :: logmsg
     character(len=CS) :: cnum
     logical           :: isPresent, isSet
+    logical           :: has_wtracers
+    integer           :: num_wtracers
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -207,6 +211,9 @@ contains
 
     if (nxg /= 0 .and. nyg /= 0) then
 
+       has_wtracers = shr_wtracers_present()
+       num_wtracers = shr_wtracers_get_num_tracers()
+
        call fld_list_add(fldsFrGlc_num, fldsFrGlc, trim(flds_scalar_name))
        call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Sg_icemask'                )
        call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Sg_icemask_coupled_fluxes' )
@@ -214,9 +221,25 @@ contains
        call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Sg_topo'                   )
        call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Flgg_hflx'                 )
 
+       call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Fgrg_rofi'                 )
+       call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Fgrg_rofl'                 )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Fgrg_rofi'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Fgrg_rofl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
+
+       ! This is needed for the smb renormalization
+       call fld_list_add(fldsFrGlc_num, fldsFrGlc, 'Sg_area')
+
        call fld_list_add(fldsToGlc_num, fldsToGlc, trim(flds_scalar_name))
        call fld_list_add(fldsToGlc_num, fldsToGlc, 'Sl_tsrf')
        call fld_list_add(fldsToGlc_num, fldsToGlc, 'Flgl_qice')
+       if (has_wtracers) then
+          call fld_list_add(fldsToGlc_num, fldsToGlc, 'Flgl_qice'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
 
        ! Now advertise import and export fields fields
        do ns = 1,num_icesheets
@@ -328,7 +351,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer           :: n, nf, nind, ns
+    integer           :: n, ns, fld_num_save
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -351,20 +374,22 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    ! Start from index 2 in order to skip the scalar field
+    fld_num_save = 1
     do ns = 1,num_icesheets
-       do nf = 2,fldsFrGlc_num
-          if (fldsFrGlc(nf)%ungridded_ubound == 0) then
-             call field_setexport(NStateExp(ns), trim(fldsFrGlc(nf)%stdname), lon, lat, nf=nf, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          else
-             do nind = 1,fldsFrGlc(nf)%ungridded_ubound
-                call field_setexport(NStateExp(ns), trim(fldsFrGlc(nf)%stdname), lon, lat, nf=nf+nind-1, &
-                     ungridded_index=nind, rc=rc)
-                if (chkerr(rc,__LINE__,u_FILE_u)) return
-             end do
-          end if
-       end do
+       call set_all_export_fields( &
+            exportState = NStateExp(ns), &
+            flds = fldsFrGlc, &
+            fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+            fld_max = fldsFrGlc_num, &
+            lon = lon, &
+            lat = lat, &
+            field_setexport = field_setexport, &
+            rc = rc, &
+            ! Save fld_num to continue to increment it for ice sheets beyond the first (so
+            ! different ice sheets will have different field values)
+            fld_num_save = fld_num_save)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
        if (dbug > 1) then
           call State_diagnose(NStateExp(ns), trim(subname)//':ES',rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
@@ -396,6 +421,12 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
+    type(ESMF_VM)     :: vm
+    real(r8)          :: lat_min_l(1), lat_max_l(1), lat_min_g(1), lat_max_g(1)
+    real(r8)          :: lon_min_l(1), lon_max_l(1), lon_min_g(1), lon_max_g(1)
+    real(r8)          :: lon_mid
+    real(r8)          :: lon_180(size(lon))  ! longitude with a -180 to 180 convention
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -425,8 +456,55 @@ contains
     else
        call ESMF_FieldGet(lfield, farrayPtr=data1d, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (fldname == 'Sg_icemask' .or.  fldname == 'Sg_icemask_coupled_fluxes' .or. fldname == 'Sg_ice_covered') then
+       if (fldname == 'Sg_icemask' .or.  fldname == 'Sg_icemask_coupled_fluxes') then
           data1d(:) = 1._r8
+       else if (fldname == 'Sg_area') then
+          ! These are not actual areas, but they'll do well enough to have some variation
+          ! in area. Note that deviations from the actual areas will lead to compensations
+          ! in the SMB renormalization. Here we set the areas to a typical order of
+          ! magnitude of actual areas on the GLC grid, but don't worry about getting the
+          ! actual areas right, just allowing this renormalization to have
+          ! bigger-than-typical correction factors.
+          data1d(:) = 1.e-6_r8 * lat(:)/90._r8
+       else if (fldname == 'Sg_ice_covered') then
+          ! Split domain into ice-covered (1) and not (0) at the midpoint of the
+          ! longitude range. We convert to [-180, 180) so that data crossing 0
+          ! degrees (the common case for ice sheet grids) is handled correctly.
+          call ESMF_VMGetCurrent(vm, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          ! Convert longitudes to -180 to 180 convention. Note that if they already were
+          ! specified as -180 to 180, the following will lead lon_180 to be the same as
+          ! lon.
+          where (lon > 180.0_R8)
+             lon_180 = lon - 360.0_R8
+          elsewhere
+             lon_180 = lon
+          end where
+
+          lon_min_l(1) = minval(lon_180)
+          lon_max_l(1) = maxval(lon_180)
+          call ESMF_VMAllReduce(vm, lon_min_l, lon_min_g, 1, ESMF_REDUCE_MIN, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_VMAllReduce(vm, lon_max_l, lon_max_g, 1, ESMF_REDUCE_MAX, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          lon_mid = (lon_min_g(1) + lon_max_g(1)) * 0.5_R8
+          do i = 1, size(data1d)
+             data1d(i) = merge(1.0_R8, 0.0_R8, lon_180(i) > lon_mid)
+          end do
+       else if (fldname == 'Sg_topo') then
+          ! Use topo values ranging from 0 to 3000 based on a latitude gradient
+          call ESMF_VMGetCurrent(vm, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          lat_min_l(1) = minval(lat)
+          lat_max_l(1) = maxval(lat)
+          call ESMF_VMAllReduce(vm, lat_min_l, lat_min_g, 1, ESMF_REDUCE_MIN, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_VMAllReduce(vm, lat_max_l, lat_max_g, 1, ESMF_REDUCE_MAX, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          do i = 1, size(data1d)
+             data1d(i) = (lat(i) - lat_min_g(1)) / (lat_max_g(1) - lat_min_g(1)) * 3000.0_R8
+          end do
        else
           do i = 1,size(data1d)
              data1d(i) = (nf*100) &

--- a/med_test_comps/xice/src/ice_comp_nuopc.F90
+++ b/med_test_comps/xice/src/ice_comp_nuopc.F90
@@ -15,10 +15,13 @@ module ice_comp_nuopc
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
+  use shr_wtracers_mod , only : WTRACERS_SUFFIX
+  use shr_wtracers_mod , only : shr_wtracers_present, shr_wtracers_get_num_tracers
   use dead_methods_mod  , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod    , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod    , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -38,7 +41,6 @@ module ice_comp_nuopc
   integer                :: fldsFrIce_num = 0
   type (fld_list_type)   :: fldsToIce(fldsMax)
   type (fld_list_type)   :: fldsFrIce(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
 
   type(ESMF_Mesh)        :: mesh
   integer                :: nxg                  ! global dim i-direction
@@ -120,6 +122,8 @@ contains
     integer            :: shrlogunit  ! original log unit
     character(len=CL)  :: logmsg
     logical            :: isPresent, isSet
+    logical            :: has_wtracers
+    integer            :: num_wtracers
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -203,12 +207,19 @@ contains
 
     if (nxg /= 0 .and. nyg /= 0) then
 
+       has_wtracers = shr_wtracers_present()
+       num_wtracers = shr_wtracers_get_num_tracers()
+
        call fld_list_add(fldsFrIce_num, fldsFrIce, trim(flds_scalar_name))
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_imask'      )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_ifrac'      )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_t'          )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_tref'       )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_qref'       )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_qref'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_snowh'      )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_u10'        )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Si_avsdr'      )
@@ -221,10 +232,18 @@ contains
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Faii_sen'      )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Faii_lwup'     )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Faii_evap'     )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrIce_num, fldsFrIce, 'Faii_evap'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Faii_swnet'    )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_melth'    )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_swpen'    )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_meltw'    )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_meltw'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_salt'     )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_taux'     )
        call fld_list_add(fldsFrIce_num, fldsFrIce, 'Fioi_tauy'     )
@@ -245,6 +264,10 @@ contains
        call fld_list_add(fldsToIce_num, fldsToIce, 'Sa_v'          )
        call fld_list_add(fldsToIce_num, fldsToIce, 'Sa_ptem'       )
        call fld_list_add(fldsToIce_num, fldsToIce, 'Sa_shum'       )
+       if (has_wtracers) then
+          call fld_list_add(fldsToIce_num, fldsToIce, 'Sa_shum'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToIce_num, fldsToIce, 'Sa_dens'       )
        call fld_list_add(fldsToIce_num, fldsToIce, 'Sa_tbot'       )
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_swvdr'    )
@@ -254,10 +277,21 @@ contains
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_lwdn'     )
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_rain'     )
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_snow'     )
+       if (has_wtracers) then
+          call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_rain'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_snow'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_bcph'  , ungridded_lbound=1, ungridded_ubound=3)
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_ocph'  , ungridded_lbound=1, ungridded_ubound=3)
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_dstwet', ungridded_lbound=1, ungridded_ubound=4)
        call fld_list_add(fldsToIce_num, fldsToIce, 'Faxa_dstdry', ungridded_lbound=1, ungridded_ubound=4)
+       if (has_wtracers) then
+          ! Note that this field only exists for tracers, not bulk
+          call fld_list_add(fldsToIce_num, fldsToIce, 'So_roce'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
 
        do n = 1,fldsFrIce_num
           if(mastertask) write(logunit,*)'Advertising From Xice ',trim(fldsFrIce(n)%stdname)
@@ -430,7 +464,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer           :: n, nf, nind
+    integer           :: n
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -453,19 +487,16 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    ! Start from index 2 in order to skip the scalar field
-    do nf = 2,fldsFrIce_num
-       if (fldsFrIce(nf)%ungridded_ubound == 0) then
-          call field_setexport(exportState, trim(fldsFrIce(nf)%stdname), lon, lat, nf=nf, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          do nind = 1,fldsFrIce(nf)%ungridded_ubound
-             call field_setexport(exportState, trim(fldsFrIce(nf)%stdname), lon, lat, nf=nf+nind-1, &
-                  ungridded_index=nind, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          end do
-       end if
-    end do
+    call set_all_export_fields( &
+         exportState = exportState, &
+         flds = fldsFrIce, &
+         fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+         fld_max = fldsFrIce_num, &
+         lon = lon, &
+         lat = lat, &
+         field_setexport = field_setexport, &
+         rc = rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(lon)
     deallocate(lat)
@@ -491,6 +522,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/med_test_comps/xlnd/src/lnd_comp_nuopc.F90
+++ b/med_test_comps/xlnd/src/lnd_comp_nuopc.F90
@@ -15,10 +15,14 @@ module lnd_comp_nuopc
   use shr_sys_mod      , only : shr_sys_abort
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_log_mod     , only : shr_log_getlogunit, shr_log_setlogunit
+  use shr_wtracers_mod, only : WTRACERS_SUFFIX
+  use shr_wtracers_mod, only : shr_wtracers_present, shr_wtracers_get_num_tracers
+  use glc_elevclass_mod, only : glc_get_elevclass_bounds
   use dead_methods_mod , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod   , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod   , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod   , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -39,7 +43,6 @@ module lnd_comp_nuopc
   integer                :: fldsFrLnd_num = 0
   type (fld_list_type)   :: fldsToLnd(fldsMax)
   type (fld_list_type)   :: fldsFrLnd(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
   integer                :: glc_nec
 
   type(ESMF_Mesh)        :: mesh
@@ -124,6 +127,8 @@ contains
     character(CL)     :: cvalue
     character(CL)     :: logmsg
     logical           :: isPresent, isSet
+    logical           :: has_wtracers
+    integer           :: num_wtracers
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -212,11 +217,18 @@ contains
        read(cvalue,*) glc_nec
        call ESMF_LogWrite('glc_nec = '// trim(cvalue), ESMF_LOGMSG_INFO)
 
+       has_wtracers = shr_wtracers_present()
+       num_wtracers = shr_wtracers_get_num_tracers()
+
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, trim(flds_scalar_name))
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_lfrin'      )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_t'          )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_tref'       )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_qref'       )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_qref'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_avsdr'      )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_anidr'      )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_avsdf'      )
@@ -225,20 +237,42 @@ contains
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_u10'        )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_fv'         )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_ram1'       )
+
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofsur'   )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofgwl'   )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofsub'   )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofi'     )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_irrig'    )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofsur'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofgwl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofsub'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_rofi'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flrl_irrig'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
+
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_taux'     )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_tauy'     )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_lat'      )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_sen'      )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_lwup'     )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_evap'     )
+       if (has_wtracers) then
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_evap'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_swnet'    )
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Fall_flxdst'   , ungridded_lbound=1, ungridded_ubound=4)
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flgl_qice_elev', ungridded_lbound=1, ungridded_ubound=glc_nec+1)
+       if (has_wtracers) then
+          call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Flgl_qice_elev'//WTRACERS_SUFFIX, &
+               ungridded_lbound=1, ungridded_ubound=glc_nec+1, num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_tsrf_elev'  , ungridded_lbound=1, ungridded_ubound=glc_nec+1)
        call fld_list_add(fldsFrLnd_num, fldsFrlnd, 'Sl_topo_elev'  , ungridded_lbound=1, ungridded_ubound=glc_nec+1)
 
@@ -251,13 +285,36 @@ contains
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Sa_pbot'      )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Sa_tbot'      )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Sa_shum'      )
+       if (has_wtracers) then
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Sa_shum'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Flrr_volr'    )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Flrr_volrmch' )
+       call fld_list_add(fldsToLnd_num, fldsToLnd, 'Flrr_flood'   )
+       if (has_wtracers) then
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Flrr_volr'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Flrr_volrmch'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Flrr_flood'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_lwdn'    )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_rainc'   )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_rainl'   )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_snowc'   )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_snowl'   )
+       if (has_wtracers) then
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_rainc'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_rainl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_snowc'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_snowl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_swndr'   )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_swvdr'   )
        call fld_list_add(fldsToLnd_num, fldsToLnd, 'Faxa_swndf'   )
@@ -447,7 +504,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer           :: n, nf, nind
+    integer           :: n
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -470,19 +527,16 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    ! Start from index 2 in order to Skip the scalar field here
-    do nf = 2,fldsFrLnd_num
-       if (fldsFrLnd(nf)%ungridded_ubound == 0) then
-          call field_setexport(exportState, trim(fldsFrLnd(nf)%stdname), lon, lat, nf=nf, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          do nind = 1,fldsFrLnd(nf)%ungridded_ubound
-             call field_setexport(exportState, trim(fldsFrLnd(nf)%stdname), lon, lat, nf=nf+nind-1, &
-                  ungridded_index=nind, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          end do
-       end if
-    end do
+    call set_all_export_fields( &
+         exportState = exportState, &
+         flds = fldsFrLnd, &
+         fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+         fld_max = fldsFrLnd_num, &
+         lon = lon, &
+         lat = lat, &
+         field_setexport = field_setexport, &
+         rc = rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(lon)
     deallocate(lat)
@@ -509,6 +563,13 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    real(r8)          :: glc_elevclass_bounds(0:glc_nec)
+    integer           :: glc_elevclass
+    real(r8)          :: topo_min, topo_max
+    real(r8)          :: sign
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
+
+    character(len=*), parameter :: subname = trim(modName)//':(field_setexport) '
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS
@@ -520,16 +581,48 @@ contains
     if (present(ungridded_index)) then
        call ESMF_FieldGet(lfield, farrayPtr=data2d, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
-       if (gridToFieldMap == 1) then
-          do i = 1,size(data2d, dim=1)
-             data2d(i,ungridded_index) = (nf*100) * cos(pi*lat(i)/180.0_R8) * &
-                  sin((pi*lon(i)/180.0_R8) - (ncomp-1)*(pi/3.0_R8) ) + (ncomp*10.0_R8)
+
+       if (fldname == 'Sl_topo_elev') then
+          ! Note that index 1 is bare ground, so need to subtract 1 from the ungridded index to get the elevation class
+          glc_elevclass = ungridded_index - 1
+          if (glc_elevclass < 0 .or. glc_elevclass > glc_nec) then
+             call shr_sys_abort(subname//'For Sl_topo_elev, ungridded_index outside glc elevclass bounds')
+          end if
+          if (glc_elevclass == 0) then
+             ! Arbitrarily set topo_min and topo_max for bare ground
+             topo_min = 0._r8
+             topo_max = 3000._r8
+          else
+             glc_elevclass_bounds = glc_get_elevclass_bounds()
+             topo_min = glc_elevclass_bounds(glc_elevclass - 1)
+             topo_max = glc_elevclass_bounds(glc_elevclass)
+          end if
+          do i = 1, size(data2d, dim=2)
+             ! Make topo vary spatially, ranging from topo_min to topo_max
+             data2d(ungridded_index,i) = topo_min + (topo_max - topo_min) * &
+                  (0.5_r8 + 0.5_r8 * cos(pi*lat(i)/180.0_R8) * sin((pi*lon(i)/180.0_R8) - (ncomp-1)*(pi/3.0_R8) ))
           end do
-       else if (gridToFieldMap == 2) then
-          do i = 1,size(data2d, dim=2)
-             data2d(ungridded_index,i) = (nf*100) * cos(pi*lat(i)/180.0_R8) * &
-                  sin((pi*lon(i)/180.0_R8) - (ncomp-1)*(pi/3.0_R8) ) + (ncomp*10.0_R8)
-          end do
+
+       else
+          ! For qice, ensure that we have a mix of positive and negative values (even for
+          ! limited ranges of lat and lon) to better exercise the SMB renormalization code in
+          ! CMEPS
+          sign = 1._r8
+          if (fldname == 'Flgl_qice_elev') then
+             if (mod(ungridded_index,2) == 0) sign = -1._r8
+          end if
+
+          if (gridToFieldMap == 1) then
+             do i = 1,size(data2d, dim=1)
+                data2d(i,ungridded_index) = sign * ((nf*100) * cos(pi*lat(i)/180.0_R8) * &
+                     sin((pi*lon(i)/180.0_R8) - (ncomp-1)*(pi/3.0_R8) ) + (ncomp*10.0_R8))
+             end do
+          else if (gridToFieldMap == 2) then
+             do i = 1,size(data2d, dim=2)
+                data2d(ungridded_index,i) = sign * ((nf*100) * cos(pi*lat(i)/180.0_R8) * &
+                     sin((pi*lon(i)/180.0_R8) - (ncomp-1)*(pi/3.0_R8) ) + (ncomp*10.0_R8))
+             end do
+          end if
        end if
     else
        call ESMF_FieldGet(lfield, farrayPtr=data1d, rc=rc)

--- a/med_test_comps/xocn/src/ocn_comp_nuopc.F90
+++ b/med_test_comps/xocn/src/ocn_comp_nuopc.F90
@@ -15,10 +15,13 @@ module ocn_comp_nuopc
   use shr_sys_mod      , only : shr_sys_abort
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_log_mod     , only : shr_log_getlogunit, shr_log_setlogunit
+  use shr_wtracers_mod , only : WTRACERS_SUFFIX
+  use shr_wtracers_mod , only : shr_wtracers_present, shr_wtracers_get_num_tracers
   use dead_methods_mod , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod   , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod   , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod   , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -39,7 +42,6 @@ module ocn_comp_nuopc
   integer                :: fldsFrOcn_num = 0
   type (fld_list_type)   :: fldsToOcn(fldsMax)
   type (fld_list_type)   :: fldsFrOcn(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
 
   type(ESMF_Mesh)        :: mesh
   integer                :: nxg                  ! global dim i-direction
@@ -123,6 +125,8 @@ contains
     character(CL)     :: cvalue
     character(len=CL) :: logmsg
     logical           :: isPresent, isSet
+    logical           :: has_wtracers
+    integer           :: num_wtracers
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -192,6 +196,9 @@ contains
 
     if (nxg /= 0 .and. nyg /= 0) then
 
+       has_wtracers = shr_wtracers_present()
+       num_wtracers = shr_wtracers_get_num_tracers()
+
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, trim(flds_scalar_name))
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_omask"      )
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_t"          )
@@ -202,10 +209,21 @@ contains
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_dhdy"       )
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth"    )
        call fld_list_add(fldsFrOcn_num, fldsFrOcn, "Fioo_q"        )
+       if (has_wtracers) then
+          ! Note that this field only exists for tracers, not bulk
+          call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_roce"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
 
        call fld_list_add(fldsToOcn_num, fldsToOcn, trim(flds_scalar_name))
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_rain"     )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_snow"     )
+       if (has_wtracers) then
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_rain"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_snow"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_lwdn"     )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swndr"    )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Faxa_swvdr"    )
@@ -217,9 +235,30 @@ contains
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_lat"      )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_lwup"     )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_evap"     )
+       if (has_wtracers) then
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_evap"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
+       call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"    )
+       if (has_wtracers) then
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_salt"     )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"     )
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"     )
+       call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofl_glc" )
+       call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofi_glc" )
+       if (has_wtracers) then
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofl_glc"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToOcn_num, fldsToOcn, "Forr_rofi_glc"//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
        call fld_list_add(fldsToOcn_num, fldsToOcn, "Sa_pslv"       )
 
        do n = 1,fldsFrOcn_num
@@ -355,7 +394,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer           :: n, nf, nind
+    integer           :: n
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -378,19 +417,16 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    ! Start from index 2 in order to Skip the scalar field here
-    do nf = 2,fldsFrOcn_num
-       if (fldsFrOcn(nf)%ungridded_ubound == 0) then
-          call field_setexport(exportState, trim(fldsFrOcn(nf)%stdname), lon, lat, nf=nf, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          do nind = 1,fldsFrOcn(nf)%ungridded_ubound
-             call field_setexport(exportState, trim(fldsFrOcn(nf)%stdname), lon, lat, nf=nf, &
-                  ungridded_index=nind, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          end do
-       end if
-    end do
+    call set_all_export_fields( &
+         exportState = exportState, &
+         flds = fldsFrOcn, &
+         fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+         fld_max = fldsFrOcn_num, &
+         lon = lon, &
+         lat = lat, &
+         field_setexport = field_setexport, &
+         rc = rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(lon)
     deallocate(lat)
@@ -417,6 +453,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/med_test_comps/xrof/src/rof_comp_nuopc.F90
+++ b/med_test_comps/xrof/src/rof_comp_nuopc.F90
@@ -15,10 +15,13 @@ module rof_comp_nuopc
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
+  use shr_wtracers_mod, only : WTRACERS_SUFFIX
+  use shr_wtracers_mod, only : shr_wtracers_present, shr_wtracers_get_num_tracers
   use dead_methods_mod  , only : chkerr, state_setscalar, state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod    , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod    , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -39,7 +42,6 @@ module rof_comp_nuopc
   integer                :: fldsFrRof_num = 0
   type (fld_list_type)   :: fldsToRof(fldsMax)
   type (fld_list_type)   :: fldsFrRof(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
 
   type(ESMF_Mesh)        :: mesh
   integer                :: nxg                  ! global dim i-direction
@@ -122,6 +124,8 @@ contains
     character(CL)     :: cvalue
     character(len=CL) :: logmsg
     logical           :: isPresent, isSet
+    logical           :: has_wtracers
+    integer           :: num_wtracers
     character(len=*),parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
@@ -193,20 +197,59 @@ contains
 
     if (nxg /= 0 .and. nyg /= 0) then
 
+       has_wtracers = shr_wtracers_present()
+       num_wtracers = shr_wtracers_get_num_tracers()
+
        call fld_list_add(fldsFrRof_num, fldsFrRof, trim(flds_scalar_name))
        call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofl')
        call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofi')
+       call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofl_glc')
+       call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofi_glc')
        call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_flood')
        call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_volr')
        call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_volrmch')
+       if (has_wtracers) then
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofi'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofl_glc'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Forr_rofi_glc'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_flood'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_volr'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsFrRof_num, fldsFrRof, 'Flrr_volrmch'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
 
        call fld_list_add(fldsToRof_num, fldsToRof, trim(flds_scalar_name))
+
        call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofsur')
        call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofgwl')
        call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofsub')
-       call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofdto')
        call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofi')
        call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_irrig')
+       call fld_list_add(fldsToRof_num, fldsToRof, 'Fgrg_rofi')
+       call fld_list_add(fldsToRof_num, fldsToRof, 'Fgrg_rofl')
+       if (has_wtracers) then
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofsur'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofgwl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofsub'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_rofi'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Flrl_irrig'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Fgrg_rofi'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+          call fld_list_add(fldsToRof_num, fldsToRof, 'Fgrg_rofl'//WTRACERS_SUFFIX, &
+               num_wtracers=num_wtracers)
+       end if
 
        do n = 1,fldsFrRof_num
           if(mastertask) write(logunit,*)'Advertising From Xrof ',trim(fldsFrRof(n)%stdname)
@@ -364,7 +407,7 @@ contains
     integer, intent(out) :: rc
 
     ! local variables
-    integer           :: n, nf, nind
+    integer           :: n
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -387,19 +430,16 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    ! Start from index 2 in order to skip the scalar field
-    do nf = 2,fldsFrRof_num
-       if (fldsFrRof(nf)%ungridded_ubound == 0) then
-          call field_setexport(exportState, trim(fldsFrRof(nf)%stdname), lon, lat, nf=nf, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          do nind = 1,fldsFrRof(nf)%ungridded_ubound
-             call field_setexport(exportState, trim(fldsFrRof(nf)%stdname), lon, lat, nf=nf+nind-1, &
-                  ungridded_index=nind, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          end do
-       end if
-    end do
+    call set_all_export_fields( &
+         exportState = exportState, &
+         flds = fldsFrRof, &
+         fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+         fld_max = fldsFrRof_num, &
+         lon = lon, &
+         lat = lat, &
+         field_setexport = field_setexport, &
+         rc = rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(lon)
     deallocate(lat)
@@ -425,6 +465,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/med_test_comps/xshare/dead_nuopc_mod.F90
+++ b/med_test_comps/xshare/dead_nuopc_mod.F90
@@ -1,6 +1,8 @@
 module dead_nuopc_mod
 
   use ESMF              , only : ESMF_Gridcomp, ESMF_State, ESMF_StateGet
+  use ESMF              , only : ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND
+  use ESMF              , only : ESMF_Field, ESMF_FieldGet
   use ESMF              , only : ESMF_Clock, ESMF_Time, ESMF_TimeInterval, ESMF_Alarm
   use ESMF              , only : ESMF_GridCompGet, ESMF_ClockGet, ESMF_ClockSet, ESMF_ClockAdvance, ESMF_AlarmSet
   use ESMF              , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_METHOD_INITIALIZE
@@ -10,6 +12,9 @@ module dead_nuopc_mod
   use ESMF              , only : operator(/=), operator(==), operator(+)
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod       , only : shr_sys_abort
+  use shr_wtracers_mod  , only : shr_wtracers_get_initial_ratio
+  use shr_wtracers_mod  , only : shr_wtracers_get_bulk_fieldname
+  use shr_wtracers_mod  , only : WTRACERS_SUFFIX
   use dead_methods_mod  , only : chkerr, alarmInit
 
   implicit none
@@ -20,12 +25,25 @@ module dead_nuopc_mod
   public :: ModelSetRunClock
   public :: fld_list_add
   public :: fld_list_realize
+  public :: set_all_export_fields
+
+  private :: set_wtracer_field
 
   ! !PUBLIC DATA MEMBERS:
+  integer, parameter, public :: fldname_maxlen = 128
+
   type fld_list_type
-    character(len=128) :: stdname
+     character(len=fldname_maxlen) :: stdname
      integer :: ungridded_lbound = 0
      integer :: ungridded_ubound = 0
+
+     ! Water tracer fields are handled via ungridded dimensions, but we track the size of
+     ! this dimension separately to better distinguish between the ungridded dimension
+     ! used for water tracers vs. the ungridded dimension used for other purposes -
+     ! particularly for the case of fields that have both. For fields that are not water
+     ! tracer fields, num_wtracers will be 0; for fields that are water tracer fields,
+     ! num_wtracers will be the number of water tracers in this simulation.
+     integer :: num_wtracers = 0
   end type fld_list_type
   public :: fld_list_type
 
@@ -96,7 +114,7 @@ contains
   end subroutine dead_read_inparms
 
   !===============================================================================
-  subroutine fld_list_add(num, fldlist, stdname, ungridded_lbound, ungridded_ubound)
+  subroutine fld_list_add(num, fldlist, stdname, ungridded_lbound, ungridded_ubound, num_wtracers)
 
     ! input/output variables
     integer                    , intent(inout) :: num
@@ -104,6 +122,10 @@ contains
     character(len=*)           , intent(in)    :: stdname
     integer,          optional , intent(in)    :: ungridded_lbound
     integer,          optional , intent(in)    :: ungridded_ubound
+
+    ! For water tracers, use num_wtracers instead of ungridded_lbound / ungridded_ubound
+    ! for the water tracer dimension:
+    integer,          optional , intent(in)    :: num_wtracers
 
     ! local variables
     character(len=*), parameter :: subname='(dead_nuopc_mod:fld_list_add)'
@@ -123,6 +145,10 @@ contains
        fldlist(num)%ungridded_ubound = ungridded_ubound
     end if
 
+    if (present(num_wtracers)) then
+       fldlist(num)%num_wtracers = num_wtracers
+    end if
+
   end subroutine fld_list_add
 
   !===============================================================================
@@ -130,7 +156,7 @@ contains
 
     use NUOPC , only : NUOPC_IsConnected, NUOPC_Realize
     use ESMF  , only : ESMF_MeshLoc_Element, ESMF_FieldCreate, ESMF_TYPEKIND_R8
-    use ESMF  , only : ESMF_MAXSTR, ESMF_Field, ESMF_State, ESMF_Mesh, ESMF_StateRemove
+    use ESMF  , only : ESMF_MAXSTR, ESMF_State, ESMF_Mesh, ESMF_StateRemove
     use ESMF  , only : ESMF_LogFoundError, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF  , only : ESMF_LogWrite, ESMF_LOGMSG_ERROR, ESMF_LOGERR_PASSTHRU
 
@@ -147,7 +173,6 @@ contains
     integer           :: n
     type(ESMF_Field)  :: field
     character(len=80) :: stdname
-    integer           :: gridtoFieldMap=2
     character(len=*),parameter  :: subname='(dead_nuopc_mod:fld_list_realize)'
     ! ----------------------------------------------
 
@@ -166,13 +191,34 @@ contains
              call ESMF_LogWrite(trim(subname)//trim(tag)//" Field = "//trim(stdname)//" is connected using mesh", &
                   ESMF_LOGMSG_INFO)
              ! Create the field
-             if (fldlist(n)%ungridded_lbound > 0 .and. fldlist(n)%ungridded_ubound > 0) then
+             if (fldlist(n)%ungridded_lbound > 0 .and. &
+                 fldlist(n)%ungridded_ubound > 0 .and. &
+                 fldlist(n)%num_wtracers > 0) then
+                ! This field has two ungridded dimensions: one for water tracers and one
+                ! for some other purpose. The second ungridded dimension will be for water
+                ! tracers.
+                field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=stdname, meshloc=ESMF_MESHLOC_ELEMENT, &
+                     ungriddedLbound=(/fldlist(n)%ungridded_lbound, 1/), &
+                     ungriddedUbound=(/fldlist(n)%ungridded_ubound, fldlist(n)%num_wtracers/), &
+                     gridToFieldMap=(/3/), rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+             else if (fldlist(n)%ungridded_lbound > 0 .and. &
+                      fldlist(n)%ungridded_ubound > 0) then
+                ! This field has one ungridded dimension
                 field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=stdname, meshloc=ESMF_MESHLOC_ELEMENT, &
                      ungriddedLbound=(/fldlist(n)%ungridded_lbound/), &
                      ungriddedUbound=(/fldlist(n)%ungridded_ubound/), &
-                     gridToFieldMap=(/gridToFieldMap/), rc=rc)
+                     gridToFieldMap=(/2/), rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+             else if (fldlist(n)%num_wtracers > 0) then
+                ! This field has one ungridded dimension, for water tracers
+                field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=stdname, meshloc=ESMF_MESHLOC_ELEMENT, &
+                     ungriddedLbound=(/1/), &
+                     ungriddedUbound=(/fldlist(n)%num_wtracers/), &
+                     gridToFieldMap=(/2/), rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
              else
+                ! This field has no ungridded dimensions
                 field = ESMF_FieldCreate(mesh, ESMF_TYPEKIND_R8, name=stdname, meshloc=ESMF_MESHLOC_ELEMENT, rc=rc)
                 if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
              end if
@@ -198,7 +244,7 @@ contains
       ! create a field with scalar data on the root pe
       ! ----------------------------------------------
 
-      use ESMF, only : ESMF_Field, ESMF_DistGrid, ESMF_Grid
+      use ESMF, only : ESMF_DistGrid, ESMF_Grid
       use ESMF, only : ESMF_DistGridCreate, ESMF_GridCreate, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
       use ESMF, only : ESMF_FieldCreate, ESMF_GridCreate, ESMF_TYPEKIND_R8
 
@@ -229,6 +275,212 @@ contains
     end subroutine SetScalarField
 
   end subroutine fld_list_realize
+
+  !================================================================================
+  subroutine set_all_export_fields(exportState, flds, fld_min, fld_max, lon, lat, field_setexport, rc, fld_num_save)
+
+    ! ----------------------------------------------
+    ! Set all export fields for a given component's state
+    !
+    ! This accepts a procedure argument for the subroutine that does the actual setting
+    ! for each field, since this procedure can differ between different xcomps.
+    !
+    ! Water tracer fields are handled specially: these are set equal to the corresponding
+    ! bulk field times the initial ratio for this tracer.
+    ! ----------------------------------------------
+
+    ! input/output arguments
+    type(ESMF_State), intent(inout)  :: exportState
+    type(fld_list_type), intent(in)  :: flds(:)
+    integer, intent(in)              :: fld_min  ! first index in flds to set
+    integer, intent(in)              :: fld_max  ! last index in flds to set
+    real(r8), intent(in)             :: lon(:)
+    real(r8), intent(in)             :: lat(:)
+    integer, intent(out)             :: rc
+
+    ! fld_num_save can be provided to continue where we left off from the last call.
+    ! This is useful for multiple ice sheets, for example, where we want different field
+    ! values for each ice sheet. It should generally be set to 1 for the initial call from
+    ! a component (but could be set to some other value if desired).
+    integer, optional, intent(inout) :: fld_num_save
+
+    interface
+       subroutine field_setexport(exportState, fldname, lon, lat, nf, ungridded_index, rc)
+          import :: ESMF_State
+          import :: r8
+
+          type(ESMF_State), intent(inout) :: exportState
+          character(len=*), intent(in)    :: fldname
+          real(r8), intent(in)            :: lon(:)
+          real(r8), intent(in)            :: lat(:)
+          integer, intent(in)             :: nf
+          integer, optional, intent(in)   :: ungridded_index
+          integer, intent(out)            :: rc
+       end subroutine field_setexport
+    end interface
+
+    ! local variables
+    integer :: nf, nind, fld_num
+    character(len=*), parameter :: subname='(dead_nuopc_mod:set_all_export_fields)'
+    ! ----------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    if (present(fld_num_save)) then
+       fld_num = fld_num_save
+    else
+       fld_num = 1
+    end if
+
+    do nf = fld_min,fld_max
+       if (flds(nf)%num_wtracers > 0) then
+          ! We'll handle water tracers specially, below. A few notes about this:
+          ! - We handle water tracers after we are done setting all non-water tracer
+          !   fields, because the setting of water tracer fields depends on the
+          !   corresponding non-tracer fields.
+          ! - We do *not* increment fld_num for the water tracer fields. This ensures that
+          !   values put in the non-tracer fields remain the same even when introducing
+          !   water tracers.
+          cycle
+       end if
+
+       if (flds(nf)%ungridded_ubound == 0) then
+          call field_setexport(exportState, trim(flds(nf)%stdname), lon, lat, nf=fld_num, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          fld_num = fld_num + 1
+       else
+          do nind = 1,flds(nf)%ungridded_ubound
+             call field_setexport(exportState, trim(flds(nf)%stdname), lon, lat, nf=fld_num, &
+                  ungridded_index=nind, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             fld_num = fld_num + 1
+          end do
+       end if
+    end do
+
+    ! Now handle water tracers.
+    do nf = fld_min,fld_max
+       if (flds(nf)%num_wtracers > 0) then
+          call set_wtracer_field(exportState, flds(nf), rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end if
+    end do
+
+    if (present(fld_num_save)) then
+       fld_num_save = fld_num
+    end if
+
+  end subroutine set_all_export_fields
+
+  !================================================================================
+  subroutine set_wtracer_field(exportState, fld, rc)
+
+    ! ----------------------------------------------
+    ! Sets a single water tracer field (for all tracers), based on the corresponding bulk
+    ! field and the initial ratio of this tracer.
+    ! ----------------------------------------------
+
+    ! input/output arguments
+    type(ESMF_State), intent(inout) :: exportState
+    type(fld_list_type), intent(in) :: fld
+    integer, intent(out)            :: rc
+
+    ! local variables
+    logical :: is_wtracer_field
+    type(ESMF_StateItem_Flag) :: bulk_item_flag
+    character(len=fldname_maxlen) :: wtracer_bulk_fldname
+
+    type(ESMF_Field) :: field_wtracers
+    type(ESMF_Field) :: field_bulk
+
+    ! If there is no ungridded dimension other than the water tracer dimension, we'll use
+    ! these variables:
+    real(r8), pointer :: data_bulk_1d(:)
+    real(r8), pointer :: data_wtracers_2d(:,:)
+
+    ! If there is an additional ungridded dimension in addition to the water tracer
+    ! dimension, we'll use these variables:
+    real(r8), pointer :: data_bulk_2d(:,:)
+    real(r8), pointer :: data_wtracers_3d(:,:,:)
+
+    integer :: n
+
+    character(len=*), parameter :: subname='(dead_nuopc_mod:set_wtracer_field)'
+    ! ----------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call shr_wtracers_get_bulk_fieldname( &
+         fieldname = fld%stdname, &
+         is_wtracer_field = is_wtracer_field, &
+         bulk_fieldname = wtracer_bulk_fldname)
+    if (.not. is_wtracer_field) then
+       call ESMF_LogWrite(subname//": ERROR: "//trim(fld%stdname)// &
+            " does not end with the expected suffix ('"//WTRACERS_SUFFIX//"') for a water tracer field", &
+            ESMF_LOGMSG_ERROR)
+       rc = ESMF_FAILURE
+       return
+    end if
+
+    call ESMF_StateGet(exportState, itemName=trim(fld%stdname), field=field_wtracers, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call ESMF_StateGet(exportState, itemName=trim(wtracer_bulk_fldname), itemType=bulk_item_flag, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    if (bulk_item_flag /= ESMF_STATEITEM_NOTFOUND) then
+       call ESMF_StateGet(exportState, itemName=trim(wtracer_bulk_fldname), field=field_bulk, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+       if (fld%ungridded_lbound > 0 .and. fld%ungridded_ubound > 0) then
+          ! There is an additional ungridded dimension in addition to the water tracer
+          ! dimension. Note that we assume that the bulk field matches the tracer field in
+          ! terms of the size of this ungridded dimension.
+          call ESMF_FieldGet(field_wtracers, farrayPtr=data_wtracers_3d, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_FieldGet(field_bulk, farrayPtr=data_bulk_2d, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          do n = 1, fld%num_wtracers
+             data_wtracers_3d(:,n,:) = data_bulk_2d(:,:) * shr_wtracers_get_initial_ratio(n)
+          end do
+       else
+          ! No additional ungridded dimension
+          call ESMF_FieldGet(field_wtracers, farrayPtr=data_wtracers_2d, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_FieldGet(field_bulk, farrayPtr=data_bulk_1d, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          do n = 1, fld%num_wtracers
+             data_wtracers_2d(n,:) = data_bulk_1d(:) * shr_wtracers_get_initial_ratio(n)
+          end do
+       end if
+    else
+       ! Corresponding bulk item not found. This is the case for a small number of fields
+       ! where we have a water tracer field but no corresponding bulk field. In this
+       ! situation, set the tracer field to the initial ratio everywhere. (It would be
+       ! ideal to give it some spatial pattern, but for now we just use a constant field
+       ! for simplicity.)
+
+       if (fld%ungridded_lbound > 0 .and. fld%ungridded_ubound > 0) then
+          ! There is an additional ungridded dimension in addition to the water tracer
+          ! dimension.
+          call ESMF_FieldGet(field_wtracers, farrayPtr=data_wtracers_3d, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          do n = 1, fld%num_wtracers
+             data_wtracers_3d(:,n,:) = shr_wtracers_get_initial_ratio(n)
+          end do
+       else
+          ! No additional ungridded dimension
+          call ESMF_FieldGet(field_wtracers, farrayPtr=data_wtracers_2d, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+          do n = 1, fld%num_wtracers
+             data_wtracers_2d(n,:) = shr_wtracers_get_initial_ratio(n)
+          end do
+       end if
+    end if
+  end subroutine set_wtracer_field
 
   !===============================================================================
   subroutine ModelInitPhase(gcomp, importState, exportState, clock, rc)

--- a/med_test_comps/xwav/src/wav_comp_nuopc.F90
+++ b/med_test_comps/xwav/src/wav_comp_nuopc.F90
@@ -19,6 +19,7 @@ module wav_comp_nuopc
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
   use dead_nuopc_mod    , only : fld_list_add, fld_list_realize, fldsMax, fld_list_type
+  use dead_nuopc_mod    , only : set_all_export_fields
 
   implicit none
   private ! except
@@ -39,7 +40,6 @@ module wav_comp_nuopc
   integer                :: fldsFrWav_num = 0
   type (fld_list_type)   :: fldsToWav(fldsMax)
   type (fld_list_type)   :: fldsFrWav(fldsMax)
-  integer, parameter     :: gridTofieldMap = 2 ! ungridded dimension is innermost
 
   type(ESMF_Mesh)        :: mesh
   integer                :: nxg                  ! global dim i-direction
@@ -349,8 +349,8 @@ contains
     integer          , intent(out)   :: rc
 
     ! local variables
-    integer           :: nfstart, ubound
-    integer           :: n, nf, nind
+    integer           :: ubound
+    integer           :: n
     real(r8), pointer :: lat(:)
     real(r8), pointer :: lon(:)
     integer           :: spatialDim
@@ -373,21 +373,16 @@ contains
        lat(n) = ownedElemCoords(2*n)
     end do
 
-    nfstart = 0 ! for fields that have ubound > 0
-    do nf = 2,fldsFrWav_num ! Start from index 2 in order to skip the scalar field
-       ubound = fldsFrWav(nf)%ungridded_ubound
-       if (ubound == 0) then
-          call field_setexport(exportState, trim(fldsFrWav(nf)%stdname), lon, lat, nf=nf, rc=rc)
-          if (chkerr(rc,__LINE__,u_FILE_u)) return
-       else
-          nfstart = nfstart + nf + ubound - 1
-          do nind = 1,ubound
-             call field_setexport(exportState, trim(fldsFrWav(nf)%stdname), lon, lat, nf=nfstart+nind-1, &
-                  ungridded_index=nind, rc=rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-          end do
-       end if
-    end do
+    call set_all_export_fields( &
+         exportState = exportState, &
+         flds = fldsFrWav, &
+         fld_min = 2, &  ! Start from index 2 in order to skip the scalar field here
+         fld_max = fldsFrWav_num, &
+         lon = lon, &
+         lat = lat, &
+         field_setexport = field_setexport, &
+         rc = rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     deallocate(lon)
     deallocate(lat)
@@ -414,6 +409,7 @@ contains
     type(ESMF_Field)  :: lfield
     real(r8), pointer :: data1d(:)
     real(r8), pointer :: data2d(:,:)
+    integer, parameter :: gridTofieldMap = 2 ! ungridded dimension is innermost
     !--------------------------------------------------
 
     rc = ESMF_SUCCESS

--- a/mediator/esmFldsExchange_cesm_mod.F90
+++ b/mediator/esmFldsExchange_cesm_mod.F90
@@ -63,11 +63,16 @@ module esmFldsExchange_cesm_mod
   use med_internalstate_mod , only : mrg_fracname_lnd2atm_state, mrg_fracname_lnd2atm_flux, map_fracname_lnd2atm
   use med_internalstate_mod , only : mrg_fracname_lnd2rof, map_fracname_lnd2rof
   use med_internalstate_mod , only : mrg_fracname_lnd2glc, map_fracname_lnd2glc
+  use shr_log_mod           , only : shr_log_error
+  use wtracers_mod          , only : wtracers_present
+  use wtracers_mod          , only : WTRACERS_SUFFIX
 
   implicit none
   public
 
   public :: esmFldsExchange_cesm
+
+  private :: set_suffix_for_water_bulk_or_tracers
 
   ! currently required mapping files
   character(len=CX)   :: rof2ocn_ice_rmap ='unset'
@@ -95,8 +100,14 @@ module esmFldsExchange_cesm_mod
   logical             :: flds_co2a                      ! Pass CO2 from ATM to surface components
   logical             :: flds_co2b                      ! Pass CO2 from ATM to LND and back from LND to ATM
   logical             :: flds_co2c                      ! Pass CO2 from ATM to surface (OCN/LND) and back from them to ATM
+  logical, private    :: has_wtracers                   ! Pass water tracer fields
+  integer, private    :: water_bulk_or_tracers_max      ! 2 if running with water tracers, 1 otherwise
   logical             :: flds_r2l_stream_channel_depths ! Pass channel depths from ROF to LND
   logical             :: add_gusts                      ! Whether to include fields related to the gustiness parameterization
+
+  ! Possible values for water_bulk_or_tracers index
+  integer, parameter, private :: water_bulk_index    = 1
+  integer, parameter, private :: water_tracers_index = 2
 
   character(*), parameter :: u_FILE_u = &
        __FILE__
@@ -136,6 +147,8 @@ contains
     ! local variables:
     type(InternalState) :: is_local
     integer             :: n, ns
+    integer             :: water_bulk_or_tracers_index  ! 1 = bulk, 2 = tracers (note that a single index covers all tracers - NOT one index per tracer)
+    character(len=len(WTRACERS_SUFFIX)) :: suffix       ! WTRACERS_SUFFIX for tracers, blank for bulk
     character(len=CL)   :: atm_mesh_name
     character(len=CL)   :: lnd_mesh_name
     character(len=CL)   :: ice_mesh_name
@@ -236,6 +249,13 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) flds_i2o_per_cat
 
+       has_wtracers = wtracers_present()
+       if (has_wtracers) then
+          water_bulk_or_tracers_max = water_tracers_index
+       else
+          water_bulk_or_tracers_max = water_bulk_index
+       end if
+
        call NUOPC_CompAttributeGet(gcomp, name='flds_r2l_stream_channel_depths', value=cvalue, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        read(cvalue,*) flds_r2l_stream_channel_depths
@@ -304,10 +324,8 @@ contains
        call addfld_from(compatm, 'Sa_z')
        call addfld_from(compatm, 'Sa_tbot')
        call addfld_from(compatm, 'Sa_pbot')
-       call addfld_from(compatm, 'Sa_shum')
        call addfld_from(compatm, 'Sa_ptem')
        call addfld_from(compatm, 'Sa_dens')
-       call addfld_from(compatm, 'Faxa_rainc')
     else
        if (is_local%wrap%aoflux_grid == 'ogrid') then
           if (mapuv_with_cart3d) then
@@ -317,16 +335,28 @@ contains
              call addmap_from(compatm, 'Sa_u' , compocn, mappatch, 'one', atm2ocn_map)
              call addmap_from(compatm, 'Sa_v' , compocn, mappatch, 'one', atm2ocn_map)
           end if
-          call addmap_from(compatm, 'Faxa_rainc', compocn, mapconsf, 'one', atm2ocn_map)
           call addmap_from(compatm, 'Sa_z'   , compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap_from(compatm, 'Sa_tbot', compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap_from(compatm, 'Sa_pbot', compocn, mapbilnr, 'one', atm2ocn_map)
-          call addmap_from(compatm, 'Sa_shum', compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap_from(compatm, 'Sa_ptem', compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap_from(compatm, 'Sa_dens', compocn, mapbilnr, 'one', atm2ocn_map)
           call addmap_from(compatm, 'Sa_pslv', compocn, mapbilnr, 'one', atm2ocn_map)
        end if
     end if
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Sa_shum'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_rainc'//trim(suffix))
+       else
+          if (is_local%wrap%aoflux_grid == 'ogrid') then
+            call addmap_from(compatm, 'Sa_shum'//trim(suffix), compocn, mapbilnr, 'one', atm2ocn_map)
+            call addmap_from(compatm, 'Faxa_rainc'//trim(suffix), compocn, mapconsf, 'one', atm2ocn_map)
+          end if
+       end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to med: swnet fluxes used for budget calculation
@@ -467,16 +497,22 @@ contains
     ! ---------------------------------------------------------------------
     ! to lnd: specific humidity at the lowest model level from atm
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Sa_shum')
-       call addfld_to(complnd, 'Sa_shum')
-    else
-       if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Sa_shum', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Sa_shum', rc=rc)) then
-          call addmap_from(compatm, 'Sa_shum', complnd, mapbilnr, 'one', atm2lnd_map)
-          call addmrg_to(complnd, 'Sa_shum', mrg_from=compatm, mrg_fld='Sa_shum', mrg_type='copy')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Sa_shum'//trim(suffix))
+          call addfld_to(complnd, 'Sa_shum'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Sa_shum'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Sa_shum'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Sa_shum'//trim(suffix), complnd, mapbilnr, 'one', atm2lnd_map)
+             call addmrg_to(complnd, 'Sa_shum'//trim(suffix), &
+                            mrg_from=compatm, mrg_fld='Sa_shum'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
+    end do
     ! ---------------------------------------------------------------------
     ! to lnd: prognostic CO2 at the lowest atm model level
     ! ---------------------------------------------------------------------
@@ -506,49 +542,63 @@ contains
     ! ---------------------------------------------------------------------
     ! to lnd: convective and large scale precipitation rate water equivalent from atm
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_rainc')
-       call addfld_to(complnd, 'Faxa_rainc')
-    else
-       if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_rainc', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_rainc', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_rainc', complnd, mapconsf, 'one', atm2lnd_map)
-          call addmrg_to(complnd, 'Faxa_rainc', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='copy')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_rainc'//trim(suffix))
+          call addfld_to(complnd, 'Faxa_rainc'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_rainc'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_rainc'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_rainc'//trim(suffix), complnd, mapconsf, 'one', atm2lnd_map)
+             call addmrg_to(complnd, 'Faxa_rainc'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_rainc'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_rainl')
-       call addfld_to(complnd, 'Faxa_rainl')
-    else
-       if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_rainl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_rainl', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_rainl', complnd, mapconsf, 'one', atm2lnd_map)
-          call addmrg_to(complnd, 'Faxa_rainl', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='copy')
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_rainl'//trim(suffix))
+          call addfld_to(complnd, 'Faxa_rainl'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_rainl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_rainl'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_rainl'//trim(suffix), complnd, mapconsf, 'one', atm2lnd_map)
+             call addmrg_to(complnd, 'Faxa_rainl'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_rainl'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
+    end do
     ! ---------------------------------------------------------------------
     ! to lnd: convective and large-scale (stable) snow rate from atm
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_snowc')
-       call addfld_to(complnd, 'Faxa_snowc')
-    else
-       if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_snowc', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_snowc', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_snowc', complnd, mapconsf, 'one', atm2lnd_map)
-          call addmrg_to(complnd, 'Faxa_snowc', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='copy')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_snowc'//trim(suffix))
+          call addfld_to(complnd, 'Faxa_snowc'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_snowc'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_snowc'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_snowc'//trim(suffix), complnd, mapconsf, 'one', atm2lnd_map)
+             call addmrg_to(complnd, 'Faxa_snowc'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_snowc'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_snowl')
-       call addfld_to(complnd, 'Faxa_snowl')
-    else
-       if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_snowl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_snowl', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_snowl', complnd, mapconsf, 'one', atm2lnd_map)
-          call addmrg_to(complnd, 'Faxa_snowl', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='copy')
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_snowl'//trim(suffix))
+          call addfld_to(complnd, 'Faxa_snowl'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(complnd)         , 'Faxa_snowl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Faxa_snowl'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_snowl'//trim(suffix), complnd, mapconsf, 'one', atm2lnd_map)
+             call addmrg_to(complnd, 'Faxa_snowl'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_snowl'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
+    end do
     ! ---------------------------------------------------------------------
     ! to lnd: downward longwave heat flux from atm
     ! ---------------------------------------------------------------------
@@ -683,36 +733,48 @@ contains
     ! to lnd: tributary water depth
     ! to lnd: tributary channel depth
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(comprof, 'Flrr_volr')
-       call addfld_to(complnd, 'Flrr_volr')
-    else
-       if ( fldchk(is_local%wrap%FBExp(complnd)         , 'Flrr_volr', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_volr', rc=rc)) then
-          call addmap_from(comprof, 'Flrr_volr', complnd, mapconsf, 'one', rof2lnd_map)
-          call addmrg_to(complnd, 'Flrr_volr', mrg_from=comprof, mrg_fld='Flrr_volr', mrg_type='copy')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(comprof, 'Flrr_volr'//trim(suffix))
+          call addfld_from(comprof, 'Flrr_volrmch'//trim(suffix))
+          call addfld_to(complnd, 'Flrr_volr'//trim(suffix))
+          call addfld_to(complnd, 'Flrr_volrmch'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBExp(complnd)         , 'Flrr_volr'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_volr'//trim(suffix), rc=rc)) then
+             call addmap_from(comprof, 'Flrr_volr'//trim(suffix), complnd, mapconsf, 'one', rof2lnd_map)
+             call addmrg_to(complnd, 'Flrr_volr'//trim(suffix), mrg_from=comprof, &
+                  mrg_fld='Flrr_volr'//trim(suffix), mrg_type='copy')
+          end if
+          if ( fldchk(is_local%wrap%FBExp(complnd)         , 'Flrr_volrmch'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_volrmch'//trim(suffix), rc=rc)) then
+             call addmap_from(comprof, 'Flrr_volrmch'//trim(suffix), complnd, mapconsf, 'one', rof2lnd_map)
+             call addmrg_to(complnd, 'Flrr_volrmch'//trim(suffix), mrg_from=comprof, &
+                  mrg_fld='Flrr_volrmch'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
-    if (phase == 'advertise') then
-       call addfld_from(comprof, 'Flrr_volrmch')
-       call addfld_to(complnd, 'Flrr_volrmch')
-    else
-       if ( fldchk(is_local%wrap%FBExp(complnd)         , 'Flrr_volrmch', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_volrmch', rc=rc)) then
-          call addmap_from(comprof, 'Flrr_volrmch', complnd, mapconsf, 'one', rof2lnd_map)
-          call addmrg_to(complnd, 'Flrr_volrmch', mrg_from=comprof, mrg_fld='Flrr_volrmch', mrg_type='copy')
+    end do
+
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(comprof, 'Flrr_flood'//trim(suffix))
+          call addfld_to(complnd, 'Flrr_flood'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBExp(complnd)         , 'Flrr_flood'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood'//trim(suffix), rc=rc)) then
+             call addmap_from(comprof, 'Flrr_flood'//trim(suffix), complnd, mapconsf, 'one', rof2lnd_map)
+             call addmrg_to(complnd, 'Flrr_flood'//trim(suffix), mrg_from=comprof, &
+                  mrg_fld='Flrr_flood'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
-    if (phase == 'advertise') then
-       call addfld_from(comprof, 'Flrr_flood')
-       call addfld_to(complnd, 'Flrr_flood')
-    else
-       if ( fldchk(is_local%wrap%FBExp(complnd)         , 'Flrr_flood', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
-          call addmap_from(comprof, 'Flrr_flood', complnd, mapconsf, 'one', rof2lnd_map)
-          call addmrg_to(complnd, 'Flrr_flood', mrg_from=comprof, mrg_fld='Flrr_flood', mrg_type='copy')
-       end if
-    end if
+    end do
+
     if (phase == 'advertise') then
        call addfld_from(comprof, 'Sr_tdepth')
        call addfld_to(complnd, 'Sr_tdepth')
@@ -967,32 +1029,40 @@ contains
        end if
     end if
 
-    if (phase == 'advertise') then
-       call addfld_from(complnd , 'Sl_qref')
-       call addfld_from(compice , 'Si_qref')
-       call addfld_aoflux('So_qref')
-       call addfld_to(compatm , 'Sx_qref')
-    else
-       if ( fldchk(is_local%wrap%FBexp(compatm), 'Sx_qref', rc=rc)) then
-          if (fldchk(is_local%wrap%FBImp(complnd,complnd ), 'Sl_qref', rc=rc)) then
-             call addmap_from(complnd , 'Sl_qref', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
-             call addmrg_to(compatm , 'Sx_qref', &
-                  mrg_from=complnd, mrg_fld='Sl_qref', mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_state)
-          end if
-          if (fldchk(is_local%wrap%FBImp(compice,compice ), 'Si_qref', rc=rc)) then
-             call addmap_from(compice , 'Si_qref', compatm, mapconsf, 'ifrac', ice2atm_map)
-             call addmrg_to(compatm , 'Sx_qref', &
-                  mrg_from=compice, mrg_fld='Si_qref', mrg_type='merge', mrg_fracname='ifrac')
-          end if
-          if (fldchk(is_local%wrap%FBMed_aoflux_o, 'So_qref', rc=rc)) then
-             if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
-                call addmap_aoflux('So_qref', compatm, mapconsf, 'ofrac', ocn2atm_map)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd , 'Sl_qref'//trim(suffix))
+          call addfld_from(compice , 'Si_qref'//trim(suffix))
+          call addfld_aoflux('So_qref'//trim(suffix))
+          call addfld_to(compatm , 'Sx_qref'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(compatm), 'Sx_qref'//trim(suffix), rc=rc)) then
+             if (fldchk(is_local%wrap%FBImp(complnd,complnd ), 'Sl_qref'//trim(suffix), rc=rc)) then
+                call addmap_from(complnd , 'Sl_qref'//trim(suffix), compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
+                call addmrg_to(compatm , 'Sx_qref'//trim(suffix), &
+                     mrg_from=complnd, mrg_fld='Sl_qref'//trim(suffix), mrg_type='merge', &
+                     mrg_fracname=mrg_fracname_lnd2atm_state)
              end if
-             call addmrg_to(compatm , 'Sx_qref', &
-                  mrg_from=compmed, mrg_fld='So_qref', mrg_type='merge', mrg_fracname='ofrac')
+             if (fldchk(is_local%wrap%FBImp(compice,compice ), 'Si_qref'//trim(suffix), rc=rc)) then
+                call addmap_from(compice , 'Si_qref'//trim(suffix), compatm, mapconsf, 'ifrac', ice2atm_map)
+                call addmrg_to(compatm , 'Sx_qref'//trim(suffix), &
+                     mrg_from=compice, mrg_fld='Si_qref'//trim(suffix), mrg_type='merge', &
+                     mrg_fracname='ifrac')
+             end if
+             if (fldchk(is_local%wrap%FBMed_aoflux_o, 'So_qref'//trim(suffix), rc=rc)) then
+                if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
+                   call addmap_aoflux('So_qref'//trim(suffix), compatm, mapconsf, 'ofrac', ocn2atm_map)
+                end if
+                call addmrg_to(compatm , 'Sx_qref'//trim(suffix), &
+                     mrg_from=compmed, mrg_fld='So_qref'//trim(suffix), mrg_type='merge', &
+                     mrg_fracname='ofrac')
+             end if
           end if
        end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to atm: merged zonal surface stress
@@ -1110,35 +1180,42 @@ contains
        end if
     end if
 
-    if (phase == 'advertise') then
-       call addfld_to(compatm, 'Faxx_evap')
-       call addfld_to(compatm, 'Faox_evap')
-       call addfld_from(complnd, 'Fall_evap')
-       call addfld_from(compice, 'Faii_evap')
-       call addfld_aoflux('Faox_evap')
-    else
-       if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_evap', rc=rc)) then
-          if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap', rc=rc)) then
-             call addmap_from(complnd , 'Fall_evap', compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
-             call addmrg_to(compatm , 'Faxx_evap', &
-                  mrg_from=complnd, mrg_fld='Fall_evap', mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_flux)
-          end if
-          if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_evap', rc=rc)) then
-             call addmap_from(compice , 'Faii_evap', compatm, mapconsf, 'ifrac', ice2atm_map)
-             call addmrg_to(compatm , 'Faxx_evap', &
-                  mrg_from=compice, mrg_fld='Faii_evap', mrg_type='merge', mrg_fracname='ifrac')
-          end if
-          if (fldchk(is_local%wrap%FBMed_aoflux_o, 'Faox_evap', rc=rc)) then
-             if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
-                call addmap_aoflux('Faox_evap', compatm, mapconsf, 'ofrac', ocn2atm_map)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_to(compatm, 'Faxx_evap'//trim(suffix))
+          call addfld_to(compatm, 'Faox_evap'//trim(suffix))
+          call addfld_from(complnd, 'Fall_evap'//trim(suffix))
+          call addfld_from(compice, 'Faii_evap'//trim(suffix))
+          call addfld_aoflux( 'Faox_evap'//trim(suffix))
+       else
+          if (fldchk(is_local%wrap%FBexp(compatm), 'Faxx_evap'//trim(suffix), rc=rc)) then
+             if ( fldchk(is_local%wrap%FBImp(complnd,complnd), 'Fall_evap'//trim(suffix), rc=rc)) then
+                call addmap_from(complnd , 'Fall_evap'//trim(suffix), compatm, mapconsf, map_fracname_lnd2atm, lnd2atm_map)
+                call addmrg_to(compatm , 'Faxx_evap'//trim(suffix), &
+                     mrg_from=complnd, mrg_fld='Fall_evap'//trim(suffix), mrg_type='merge', mrg_fracname=mrg_fracname_lnd2atm_flux)
              end if
-             call addmrg_to(compatm , 'Faxx_evap', &
-                  mrg_from=compmed, mrg_fld='Faox_evap', mrg_type='merge', mrg_fracname='ofrac')
-             ! unmerged aoflux-only for correct hevap to ocean in cam_out
-             call addmrg_to(compatm, 'Faox_evap', mrg_from=compmed, mrg_fld='Faox_evap', mrg_type='copy')
+             if (fldchk(is_local%wrap%FBImp(compice,compice), 'Faii_evap'//trim(suffix), rc=rc)) then
+                call addmap_from(compice , 'Faii_evap'//trim(suffix), compatm, mapconsf, 'ifrac', ice2atm_map)
+                call addmrg_to(compatm , 'Faxx_evap'//trim(suffix), &
+                     mrg_from=compice, mrg_fld='Faii_evap'//trim(suffix), mrg_type='merge', mrg_fracname='ifrac')
+             end if
+             if (fldchk(is_local%wrap%FBMed_aoflux_o, 'Faox_evap'//trim(suffix), rc=rc)) then
+                if (trim(is_local%wrap%aoflux_grid) == 'ogrid') then
+                   call addmap_aoflux('Faox_evap'//trim(suffix), compatm, mapconsf, 'ofrac', ocn2atm_map)
+                end if
+                call addmrg_to(compatm , 'Faxx_evap'//trim(suffix), &
+                     mrg_from=compmed, mrg_fld='Faox_evap'//trim(suffix), mrg_type='merge', mrg_fracname='ofrac')
+                ! unmerged aoflux-only for correct hevap to ocean in cam_out
+                call addmrg_to(compatm, 'Faox_evap'//trim(suffix), &
+                     mrg_from=compmed, mrg_fld='Faox_evap'//trim(suffix), mrg_type='copy')
+             end if
+
           end if
        end if
-    end if
+    end do
 
     if (phase == 'advertise') then
        call addfld_to(compatm, 'Faxx_lwup')
@@ -1811,40 +1888,46 @@ contains
     !  to ocn: snow rate water equivalent from atm
     ! ---------------------------------------------------------------------
 
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_rainc')
-       call addfld_from(compatm, 'Faxa_rainl')
-       call addfld_to(compocn, 'Faxa_rain' )
-       call addfld_from(compatm, 'Faxa_snowc')
-       call addfld_from(compatm, 'Faxa_snowl')
-       call addfld_to(compocn, 'Faxa_snow' )
-    else
-       ! TODO: why are we not merging Faxa_rain and Faxa_snow if they are sent from atm with ofrac
-       ! Note that the mediator atm/ocn flux calculation needs Faxa_rainc for the gustiness parameterization
-       ! which by default is not actually used
-       if ( fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainc', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(compocn)        , 'Faxa_rain' , rc=rc)) then
-          call addmap_from(compatm, 'Faxa_rainl', compocn, mapconsf, 'one', atm2ocn_map)
-          call addmap_from(compatm, 'Faxa_rainc', compocn, mapconsf, 'one', atm2ocn_map)
-          call addmrg_to(compocn, 'Faxa_rain' , mrg_from=compatm, mrg_fld='Faxa_rainc:Faxa_rainl', &
-               mrg_type='sum_with_weights', mrg_fracname='ofrac')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_rainc'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_rainl'//trim(suffix))
+          call addfld_to(compocn, 'Faxa_rain'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_snowc'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_snowl'//trim(suffix))
+          call addfld_to(compocn, 'Faxa_snow'//trim(suffix))
+       else
+          ! TODO: why are we not merging Faxa_rain and Faxa_snow if they are sent from atm with ofrac
+          ! Note that the mediator atm/ocn flux calculation needs Faxa_rainc for the gustiness parameterization
+          ! which by default is not actually used
+          if ( fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainc'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(compocn)        , 'Faxa_rain'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_rainl'//trim(suffix), compocn, mapconsf, 'one', atm2ocn_map)
+             call addmap_from(compatm, 'Faxa_rainc'//trim(suffix), compocn, mapconsf, 'one', atm2ocn_map)
+             call addmrg_to(compocn, 'Faxa_rain'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_rainc'//trim(suffix)//':Faxa_rainl'//trim(suffix), &
+                  mrg_type='sum_with_weights', mrg_fracname='ofrac')
+          end if
+          if ( fldchk(is_local%wrap%FBExp(compocn)        , 'Faxa_snow'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowc'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_snowl'//trim(suffix), compocn, mapconsf, 'one', atm2ocn_map)
+             call addmap_from(compatm, 'Faxa_snowc'//trim(suffix), compocn, mapconsf, 'one', atm2ocn_map)
+             call addmrg_to(compocn, 'Faxa_snow'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_snowc'//trim(suffix)//':Faxa_snowl'//trim(suffix), &
+                  mrg_type='sum_with_weights', mrg_fracname='ofrac')
+          end if
        end if
-       if ( fldchk(is_local%wrap%FBExp(compocn)        , 'Faxa_snow' , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowc', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_snowl', compocn, mapconsf, 'one', atm2ocn_map)
-          call addmap_from(compatm, 'Faxa_snowc', compocn, mapconsf, 'one', atm2ocn_map)
-          call addmrg_to(compocn, 'Faxa_snow'  , &
-               mrg_from=compatm, mrg_fld='Faxa_snowc:Faxa_snowl', mrg_type='sum_with_weights', mrg_fracname='ofrac')
-       end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to ocn: merged sensible heat flux
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
-       call addfld_from(compatm , 'Faxa_sen')
        call addfld_aoflux('Faox_sen')
        call addfld_from(compice , 'Fioi_melth')
        call addfld_to(compocn , 'Foxx_sen')
@@ -1860,21 +1943,28 @@ contains
     ! to ocn: surface latent heat flux and evaporation water flux
     ! ---------------------------------------------------------------------
     if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_lat' )
        call addfld_aoflux( 'Faox_lat' )
-       call addfld_aoflux( 'Faox_evap')
        call addfld_to(compocn, 'Foxx_lat' )
-       call addfld_to(compocn, 'Foxx_evap')
     else
        if ( fldchk(is_local%wrap%FBexp(compocn), 'Foxx_lat', rc=rc)) then
           call addmrg_to(compocn, 'Foxx_lat', &
                mrg_from=compmed, mrg_fld='Faox_lat', mrg_type='merge', mrg_fracname='ofrac')
        end if
-       if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_evap', rc=rc)) then
-          call addmrg_to(compocn, 'Foxx_evap', &
-               mrg_from=compmed, mrg_fld='Faox_evap', mrg_type='merge', mrg_fracname='ofrac')
-       end if
     end if
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_aoflux( 'Faox_evap'//trim(suffix))
+          call addfld_to(compocn, 'Foxx_evap'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_evap'//trim(suffix), rc=rc)) then
+             call addmrg_to(compocn, 'Foxx_evap'//trim(suffix), &
+                  mrg_from=compmed, mrg_fld='Faox_evap'//trim(suffix), mrg_type='merge', mrg_fracname='ofrac')
+          end if
+       end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to ocn: wind speed squared at 10 meters from med
@@ -2057,17 +2147,22 @@ contains
     ! ---------------------------------------------------------------------
     ! to ocn: water flux due to melting ice from ice
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compice , 'Fioi_meltw')
-       call addfld_to(compocn , 'Fioi_meltw')
-    else
-       if ( fldchk(is_local%wrap%FBexp(compocn)         , 'Fioi_meltw', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compice, compice), 'Fioi_meltw', rc=rc)) then
-          call addmap_from(compice, 'Fioi_meltw',    compocn,  mapfcopy, 'unset', 'unset')
-          call addmrg_to(compocn, 'Fioi_meltw', &
-               mrg_from=compice, mrg_fld='Fioi_meltw', mrg_type='copy_with_weights', mrg_fracname='ifrac')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compice , 'Fioi_meltw'//trim(suffix))
+          call addfld_to(compocn , 'Fioi_meltw'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(compocn)         , 'Fioi_meltw'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compice, compice), 'Fioi_meltw'//trim(suffix), rc=rc)) then
+             call addmap_from(compice, 'Fioi_meltw'//trim(suffix),    compocn,  mapfcopy, 'unset', 'unset')
+             call addmrg_to(compocn, 'Fioi_meltw'//trim(suffix), &
+                  mrg_from=compice, mrg_fld='Fioi_meltw'//trim(suffix), mrg_type='copy_with_weights', mrg_fracname='ifrac')
+          end if
        end if
-    end if
+    end do
     ! ---------------------------------------------------------------------
     ! to ocn: heat flux from melting ice from ice
     ! ---------------------------------------------------------------------
@@ -2148,116 +2243,127 @@ contains
     !-----------------------------
 
     if (phase == 'advertise') then
-       ! Note that Flrr_flood below needs to be added to
-       ! fldlistFr(comprof) in order to be mapped correctly to the ocean but the ocean
-       ! does not receive it so it is advertised but it will not be connected
-       call addfld_from(comprof, 'Forr_rofl')
        call addfld_from(comprof, 'Forr_rofl_nonh2o')
-       call addfld_from(comprof, 'Forr_rofi')
-       call addfld_from(comprof, 'Forr_rofl_glc')
-       call addfld_from(comprof, 'Forr_rofi_glc')
-       call addfld_to(compocn, 'Foxx_rofl')
-       call addfld_to(compocn, 'Foxx_rofi')
        call addfld_to(compocn, 'Forr_rofl_nonh2o')
-       call addfld_to(compocn, 'Forr_rofl_glc')
-       call addfld_to(compocn, 'Forr_rofi_glc')
-       call addfld_to(compocn, 'Flrr_flood')
     else
-      ! Liquid runoff from land and glc - mapping
-      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl' , rc=rc)) then
-        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
-          if (trim(rof2ocn_liq_rmap) == 'unset') then
-            call addmap_from(comprof, 'Forr_rofl', compocn, mapconsd, 'one', 'unset')
-          else
-            call addmap_from(comprof, 'Forr_rofl', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
+       if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_nonh2o' , rc=rc)) then
+          if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_nonh2o' , rc=rc)) then
+             if (trim(rof2ocn_liq_rmap) == 'unset') then
+                call addmap_from(comprof, 'Forr_rofl_nonh2o', compocn, mapconsd, 'one', 'unset')
+             else
+                call addmap_from(comprof, 'Forr_rofl_nonh2o', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
+             end if
           end if
-        end if
-      end if
-      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_nonh2o' , rc=rc)) then
-        if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_nonh2o' , rc=rc)) then
-          if (trim(rof2ocn_liq_rmap) == 'unset') then
-            call addmap_from(comprof, 'Forr_rofl_nonh2o', compocn, mapconsd, 'one', 'unset')
-          else
-            call addmap_from(comprof, 'Forr_rofl_nonh2o', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
-          end if
-        end if
-      end if
-      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
-        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
-          call addmap_from(comprof, 'Flrr_flood', compocn, mapconsd, 'one', rof2ocn_map)
-        end if
-      end if
-      if ( fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
-        if (fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc', rc=rc) .or. &
-            fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl', rc=rc)) then
-          if (trim(rof2ocn_liq_rmap) == 'unset') then
-            call addmap_from(comprof, 'Forr_rofl_glc', compocn, mapconsd, 'one', 'unset')
-          else
-            call addmap_from(comprof, 'Forr_rofl_glc', compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
-          end if
-        end if
-      end if
-
-      ! Liquid runoff from land and glc - merging
-      forr_rofl_glc_merged_to_ocn = .false.
-      if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc', rc=rc) .and. &
-           fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc)) then
-        ! If the ocean is prepared to handle Forr_rofl_glc as a separate field, then keep
-        ! it as a separate field rather than merging it to Foxx_rofl
-        call addmrg_to(compocn, 'Forr_rofl_glc', mrg_from=comprof, mrg_fld='Forr_rofl_glc', mrg_type='copy')
-        forr_rofl_glc_merged_to_ocn = .true.
-      end if
-      if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl' , rc=rc)) then
-        mrgfld_source = 'Forr_rofl'
-        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood', rc=rc)) then
-          mrgfld_source = trim(mrgfld_source) //':Flrr_flood'
-        end if
-        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc', rc=rc) .and. &
-            .not. forr_rofl_glc_merged_to_ocn) then
-          mrgfld_source = trim(mrgfld_source) //':Forr_rofl_glc'
-        end if
-        call addmrg_to(compocn, 'Foxx_rofl', mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
-      end if
-
-      ! Frozen runoff from land and glc - mapping
-      if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi' , rc=rc)) then
-        if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
-          if (trim(rof2ocn_ice_rmap) == 'unset') then
-            call addmap_from(comprof, 'Forr_rofi', compocn, mapconsd, 'one', 'unset')
-          else
-            call addmap_from(comprof, 'Forr_rofi', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
-          end if
-        end if
-      end if
-      if ( fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
-        if (fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc', rc=rc) .or. &
-            fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi', rc=rc)) then
-          if (trim(rof2ocn_ice_rmap) == 'unset') then
-            call addmap_from(comprof, 'Forr_rofi_glc', compocn, mapconsd, 'one', 'unset')
-          else
-            call addmap_from(comprof, 'Forr_rofi_glc', compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
-          end if
-        end if
-      end if
-
-      ! Frozen runoff from land and glc - merging
-      forr_rofi_glc_merged_to_ocn = .false.
-      if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc', rc=rc) .and. &
-           fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc)) then
-        ! If the ocean is prepared to handle Forr_rofi_glc as a separate field, then keep
-        ! it as a separate field rather than merging it to Foxx_rofi
-        call addmrg_to(compocn, 'Forr_rofi_glc', mrg_from=comprof, mrg_fld='Forr_rofi_glc', mrg_type='copy')
-        forr_rofi_glc_merged_to_ocn = .true.
-      end if
-      if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi' , rc=rc)) then
-        mrgfld_source = 'Forr_rofi'
-        if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc', rc=rc) .and. &
-            .not. forr_rofi_glc_merged_to_ocn) then
-          mrgfld_source = trim(mrgfld_source) //':Forr_rofi_glc'
-        end if
-        call addmrg_to(compocn, 'Foxx_rofi', mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
-      end if
+       end if
     end if
+
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          ! Note that Flrr_flood below needs to be added to
+          ! fldlistFr(comprof) in order to be mapped correctly to the ocean but the ocean
+          ! does not receive it so it is advertised but it will not be connected
+          call addfld_from(comprof, 'Forr_rofl'//trim(suffix))
+          call addfld_from(comprof, 'Forr_rofi'//trim(suffix))
+          call addfld_from(comprof, 'Forr_rofl_glc'//trim(suffix))
+          call addfld_from(comprof, 'Forr_rofi_glc'//trim(suffix))
+          call addfld_to(compocn, 'Foxx_rofl'//trim(suffix))
+          call addfld_to(compocn, 'Foxx_rofi'//trim(suffix))
+          call addfld_to(compocn, 'Forr_rofl_glc'//trim(suffix))
+          call addfld_to(compocn, 'Forr_rofi_glc'//trim(suffix))
+          call addfld_to(compocn, 'Flrr_flood'//trim(suffix))
+       else
+         ! Liquid runoff from land and glc - mapping
+         if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl'//trim(suffix) , rc=rc)) then
+           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl'//trim(suffix) , rc=rc)) then
+             if (trim(rof2ocn_liq_rmap) == 'unset') then
+               call addmap_from(comprof, 'Forr_rofl'//trim(suffix), compocn, mapconsd, 'one', 'unset')
+             else
+               call addmap_from(comprof, 'Forr_rofl'//trim(suffix), compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
+             end if
+           end if
+         end if
+         if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood'//trim(suffix), rc=rc)) then
+           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl'//trim(suffix), rc=rc)) then
+             call addmap_from(comprof, 'Flrr_flood'//trim(suffix), compocn, mapconsd, 'one', rof2ocn_map)
+           end if
+         end if
+         if ( fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc'//trim(suffix), rc=rc)) then
+           if (fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc'//trim(suffix), rc=rc) .or. &
+               fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl'//trim(suffix), rc=rc)) then
+             if (trim(rof2ocn_liq_rmap) == 'unset') then
+               call addmap_from(comprof, 'Forr_rofl_glc'//trim(suffix), compocn, mapconsd, 'one', 'unset')
+             else
+               call addmap_from(comprof, 'Forr_rofl_glc'//trim(suffix), compocn, map_rof2ocn_liq, 'none', rof2ocn_liq_rmap)
+             end if
+           end if
+         end if
+
+         ! Liquid runoff from land and glc - merging
+         forr_rofl_glc_merged_to_ocn = .false.
+         if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofl_glc'//trim(suffix), rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc'//trim(suffix), rc=rc)) then
+           ! If the ocean is prepared to handle Forr_rofl_glc as a separate field, then keep
+           ! it as a separate field rather than merging it to Foxx_rofl
+           call addmrg_to(compocn, 'Forr_rofl_glc'//trim(suffix), mrg_from=comprof, &
+                mrg_fld='Forr_rofl_glc'//trim(suffix), mrg_type='copy')
+           forr_rofl_glc_merged_to_ocn = .true.
+         end if
+         if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofl'//trim(suffix), rc=rc)) then
+           mrgfld_source = 'Forr_rofl'//trim(suffix)
+           if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Flrr_flood'//trim(suffix), rc=rc)) then
+             mrgfld_source = trim(mrgfld_source) //':Flrr_flood'//trim(suffix)
+           end if
+           if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofl_glc'//trim(suffix), rc=rc) .and. &
+               .not. forr_rofl_glc_merged_to_ocn) then
+             mrgfld_source = trim(mrgfld_source) //':Forr_rofl_glc'//trim(suffix)
+           end if
+           call addmrg_to(compocn, 'Foxx_rofl'//trim(suffix), mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
+         end if
+
+         ! Frozen runoff from land and glc - mapping
+         if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi'//trim(suffix), rc=rc)) then
+           if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi'//trim(suffix), rc=rc)) then
+             if (trim(rof2ocn_ice_rmap) == 'unset') then
+               call addmap_from(comprof, 'Forr_rofi'//trim(suffix), compocn, mapconsd, 'one', 'unset')
+             else
+               call addmap_from(comprof, 'Forr_rofi'//trim(suffix), compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
+             end if
+           end if
+         end if
+         if ( fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc'//trim(suffix), rc=rc)) then
+           if (fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc'//trim(suffix), rc=rc) .or. &
+               fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi'//trim(suffix), rc=rc)) then
+             if (trim(rof2ocn_ice_rmap) == 'unset') then
+               call addmap_from(comprof, 'Forr_rofi_glc'//trim(suffix), compocn, mapconsd, 'one', 'unset')
+             else
+               call addmap_from(comprof, 'Forr_rofi_glc'//trim(suffix), compocn, map_rof2ocn_ice, 'none', rof2ocn_ice_rmap)
+             end if
+           end if
+         end if
+
+         ! Frozen runoff from land and glc - merging
+         forr_rofi_glc_merged_to_ocn = .false.
+         if ( fldchk(is_local%wrap%FBExp(compocn), 'Forr_rofi_glc'//trim(suffix), rc=rc) .and. &
+              fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc'//trim(suffix), rc=rc)) then
+           ! If the ocean is prepared to handle Forr_rofi_glc as a separate field, then keep
+           ! it as a separate field rather than merging it to Foxx_rofi
+           call addmrg_to(compocn, 'Forr_rofi_glc'//trim(suffix), mrg_from=comprof, &
+                mrg_fld='Forr_rofi_glc'//trim(suffix), mrg_type='copy')
+           forr_rofi_glc_merged_to_ocn = .true.
+         end if
+         if ( fldchk(is_local%wrap%FBExp(compocn), 'Foxx_rofi'//trim(suffix), rc=rc)) then
+           mrgfld_source = 'Forr_rofi'//trim(suffix)
+           if (fldchk(is_local%wrap%FBImp(comprof, comprof), 'Forr_rofi_glc'//trim(suffix), rc=rc) .and. &
+               .not. forr_rofi_glc_merged_to_ocn) then
+             mrgfld_source = trim(mrgfld_source) //':Forr_rofi_glc'//trim(suffix)
+           end if
+           call addmrg_to(compocn, 'Foxx_rofi'//trim(suffix), mrg_from=comprof, mrg_fld=trim(mrgfld_source), mrg_type='sum')
+         end if
+       end if
+    end do
 
     !-----------------------------
     ! from wav: for daily averaged fields for
@@ -2764,44 +2870,53 @@ contains
     ! to ice: convective and large scale precipitation rate water equivalent from atm
     ! to ice: rain and snow rate from atm
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_rainc')
-       call addfld_from(compatm, 'Faxa_rainl')
-       call addfld_from(compatm, 'Faxa_rain' )
-       call addfld_to(compice, 'Faxa_rain' )
-    else
-       if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_rain' , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainc', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_rainc', compice, mapconsf, 'one', atm2ice_map)
-          call addmap_from(compatm, 'Faxa_rainl', compice, mapconsf, 'one', atm2ice_map)
-          call addmrg_to(compice, 'Faxa_rain' , mrg_from=compatm, mrg_fld='Faxa_rainc:Faxa_rainl', mrg_type='sum')
-       else if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_rain', rc=rc) .and. &
-                 fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rain', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_rain', compice, mapconsf, 'one', atm2ice_map)
-          call addmrg_to(compice, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rain', mrg_type='copy')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_rainc'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_rainl'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_rain'//trim(suffix))
+          call addfld_to(compice, 'Faxa_rain'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_rain'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rainc'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_rainc'//trim(suffix), compice, mapconsf, 'one', atm2ice_map)
+             call addmap_from(compatm, 'Faxa_rainl'//trim(suffix), compice, mapconsf, 'one', atm2ice_map)
+             call addmrg_to(compice, 'Faxa_rain'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_rainc'//trim(suffix)//':Faxa_rainl'//trim(suffix), &
+                  mrg_type='sum')
+          else if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_rain'//trim(suffix), rc=rc) .and. &
+                    fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_rain'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_rain'//trim(suffix), compice, mapconsf, 'one', atm2ice_map)
+             call addmrg_to(compice, 'Faxa_rain'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_rain'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Faxa_snowc')
-       call addfld_from(compatm, 'Faxa_snowl')
-       call addfld_from(compatm, 'Faxa_snow' )
-       call addfld_to(compice, 'Faxa_snow' )
-    else
-       if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_snow' , rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowc', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_snowc', compice, mapconsf, 'one', atm2ice_map)
-          call addmap_from(compatm, 'Faxa_snowl', compice, mapconsf, 'one', atm2ice_map)
-          call addmrg_to(compice, 'Faxa_snow' , &
-               mrg_from=compatm, mrg_fld='Faxa_snowc:Faxa_snowl', mrg_type='sum')
-       else if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_snow', rc=rc) .and. &
-                 fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snow', rc=rc)) then
-          call addmap_from(compatm, 'Faxa_snow', compice, mapconsf, 'one', atm2ice_map)
-          call addmrg_to(compice, 'Faxa_snow', &
-               mrg_from=compatm, mrg_fld='Faxa_snow', mrg_type='copy')
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Faxa_snowc'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_snowl'//trim(suffix))
+          call addfld_from(compatm, 'Faxa_snow'//trim(suffix))
+          call addfld_to(compice, 'Faxa_snow'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_snow'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snowc'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_snowc'//trim(suffix), compice, mapconsf, 'one', atm2ice_map)
+             call addmap_from(compatm, 'Faxa_snowl'//trim(suffix), compice, mapconsf, 'one', atm2ice_map)
+             call addmrg_to(compice, 'Faxa_snow'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_snowc'//trim(suffix)//':Faxa_snowl'//trim(suffix), &
+                  mrg_type='sum')
+          else if ( fldchk(is_local%wrap%FBexp(compice)        , 'Faxa_snow'//trim(suffix), rc=rc) .and. &
+                    fldchk(is_local%wrap%FBImp(compatm,compatm), 'Faxa_snow'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Faxa_snow'//trim(suffix), compice, mapconsf, 'one', atm2ice_map)
+             call addmrg_to(compice, 'Faxa_snow'//trim(suffix), mrg_from=compatm, &
+                  mrg_fld='Faxa_snow'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to ice: height at the lowest model level from atm
@@ -2903,16 +3018,22 @@ contains
     ! ---------------------------------------------------------------------
     ! to ice: specific humidity at the lowest model level from atm
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(compatm, 'Sa_shum')
-       call addfld_to(compice, 'Sa_shum')
-    else
-       if ( fldchk(is_local%wrap%FBexp(compice)         , 'Sa_shum', rc=rc) .and. &
-            fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Sa_shum', rc=rc)) then
-          call addmap_from(compatm, 'Sa_shum', compice, mapbilnr, 'one', atm2ice_map)
-          call addmrg_to(compice, 'Sa_shum', mrg_from=compatm, mrg_fld='Sa_shum', mrg_type='copy')
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compatm, 'Sa_shum'//trim(suffix))
+          call addfld_to(compice, 'Sa_shum'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBexp(compice)         , 'Sa_shum'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm,compatm ), 'Sa_shum'//trim(suffix), rc=rc)) then
+             call addmap_from(compatm, 'Sa_shum'//trim(suffix), compice, mapbilnr, 'one', atm2ice_map)
+             call addmrg_to(compice, 'Sa_shum'//trim(suffix), &
+                            mrg_from=compatm, mrg_fld='Sa_shum'//trim(suffix), mrg_type='copy')
+          end if
        end if
-    end if
+    end do
     ! ---------------------------------------------------------------------
     ! to ice: sea surface temperature from ocn
     ! ---------------------------------------------------------------------
@@ -3015,6 +3136,25 @@ contains
          end if
       end if
     end if
+    !-----------------------------
+    ! to ice: Ratio of ocean surface level abund. H2_16O/H2O/Rstd from ocean
+    !-----------------------------
+    ! Note that this field is JUST for water tracers, NOT for bulk - so we start the loop at water_tracers_index
+    do water_bulk_or_tracers_index = water_tracers_index, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(compocn, 'So_roce'//trim(suffix))
+          call addfld_to(compice, 'So_roce'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBImp(compocn, compocn), 'So_roce'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(compice)         , 'So_roce'//trim(suffix), rc=rc)) then
+             call addmap_from(compocn, 'So_roce'//trim(suffix), compice,  mapfcopy, 'unset', 'unset')
+             call addmrg_to(compice, 'So_roce'//trim(suffix), mrg_from=compocn, mrg_fld='So_roce'//trim(suffix), mrg_type='copy')
+          end if
+       end if
+    end do
     ! ---------------------------------------------------------------------
     ! to ice: wave elevation spectrum (field with ungridded dimensions)
     ! ---------------------------------------------------------------------
@@ -3199,41 +3339,52 @@ contains
     ! ---------------------------------------------------------------------
     ! to rof: liquid and ice from glc
     ! ---------------------------------------------------------------------
-    do ns = 1, is_local%wrap%num_icesheets
-       if (phase == 'advertise') then
-          call addfld_from(compglc(ns), 'Fgrg_rofl')
-          call addfld_from(compglc(ns), 'Fgrg_rofi')
-          call addfld_to(comprof, 'Fgrg_rofl')
-          call addfld_to(comprof, 'Fgrg_rofi')
-       else
-          ! Note: we are assuming that the rof mesh has a mask of one everywhere
-          if ( fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl', rc=rc) .and. &
-               fldchk(is_local%wrap%FBExp(comprof)                 , 'Fgrg_rofl', rc=rc)) then
-             call addmap_from(compglc(ns), 'Fgrg_rofl', comprof, mapconsd, 'gfrac' , 'unset')
-             ! Custom merge in med_phases_prep_rof
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       do ns = 1, is_local%wrap%num_icesheets
+          if (phase == 'advertise') then
+             call addfld_from(compglc(ns), 'Fgrg_rofl'//trim(suffix))
+             call addfld_from(compglc(ns), 'Fgrg_rofi'//trim(suffix))
+             call addfld_to(comprof, 'Fgrg_rofl'//trim(suffix))
+             call addfld_to(comprof, 'Fgrg_rofi'//trim(suffix))
+          else
+             ! Note: we are assuming that the rof mesh has a mask of one everywhere
+             if ( fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofl'//trim(suffix), rc=rc) .and. &
+                  fldchk(is_local%wrap%FBExp(comprof)                 , 'Fgrg_rofl'//trim(suffix), rc=rc)) then
+                call addmap_from(compglc(ns), 'Fgrg_rofl'//trim(suffix), comprof, mapconsd, 'gfrac' , 'unset')
+                ! Custom merge in med_phases_prep_rof
+             end if
+             if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi'//trim(suffix), rc=rc) .and. &
+                 fldchk(is_local%wrap%FBExp(comprof)                 , 'Fgrg_rofi'//trim(suffix), rc=rc)) then
+                call addmap_from(compglc(ns), 'Fgrg_rofi'//trim(suffix), comprof, mapconsd, 'gfrac', 'unset')
+                ! Custom merge in med_phases_prep_rof
+             end if
           end if
-          if (fldchk(is_local%wrap%FBImp(compglc(ns), compglc(ns)), 'Fgrg_rofi', rc=rc) .and. &
-              fldchk(is_local%wrap%FBExp(comprof)                 , 'Fgrg_rofi', rc=rc)) then
-             call addmap_from(compglc(ns), 'Fgrg_rofi', comprof, mapconsd, 'gfrac', 'unset')
-             ! Custom merge in med_phases_prep_rof
-          end if
-       end if
+       end do
     end do
 
     ! ---------------------------------------------------------------------
     ! to rof: water flux from land (liquid surface)
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(complnd, 'Flrl_rofsur')
-       call addfld_to(comprof, 'Flrl_rofsur')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsur', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsur', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofsur', comprof, mapconsf, map_fracname_lnd2rof, 'unset')
-          call addmrg_to(comprof, 'Flrl_rofsur', &
-               mrg_from=complnd, mrg_fld='Flrl_rofsur', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd, 'Flrl_rofsur'//trim(suffix))
+          call addfld_to(comprof, 'Flrl_rofsur'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsur'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsur'//trim(suffix), rc=rc)) then
+             call addmap_from(complnd, 'Flrl_rofsur'//trim(suffix), comprof, mapconsf, map_fracname_lnd2rof, 'unset')
+             call addmrg_to(comprof, 'Flrl_rofsur'//trim(suffix), &
+                  mrg_from=complnd, mrg_fld='Flrl_rofsur'//trim(suffix), &
+                  mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+          end if
        end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to rof: non-water flux(es) from land (liquid surface)
@@ -3253,62 +3404,86 @@ contains
     ! ---------------------------------------------------------------------
     ! to rof: water flux from land (ice surface)
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(complnd, 'Flrl_rofi')
-       call addfld_to(comprof, 'Flrl_rofi')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofi', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofi', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofi', comprof, mapconsf, map_fracname_lnd2rof, 'unset')
-          call addmrg_to(comprof, 'Flrl_rofi', &
-               mrg_from=complnd, mrg_fld='Flrl_rofi', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd, 'Flrl_rofi'//trim(suffix))
+          call addfld_to(comprof, 'Flrl_rofi'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofi'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofi'//trim(suffix), rc=rc)) then
+             call addmap_from(complnd, 'Flrl_rofi'//trim(suffix), comprof, mapconsf, map_fracname_lnd2rof, 'unset')
+             call addmrg_to(comprof, 'Flrl_rofi'//trim(suffix), &
+                  mrg_from=complnd, mrg_fld='Flrl_rofi'//trim(suffix), &
+                  mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+          end if
        end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to rof: water flux from land (liquid glacier, wetland, and lake)
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(complnd, 'Flrl_rofgwl')
-       call addfld_to(comprof, 'Flrl_rofgwl')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofgwl', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofgwl', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofgwl', comprof, mapconsf, map_fracname_lnd2rof, 'unset')
-          call addmrg_to(comprof, 'Flrl_rofgwl', &
-               mrg_from=complnd, mrg_fld='Flrl_rofgwl', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd, 'Flrl_rofgwl'//trim(suffix))
+          call addfld_to(comprof, 'Flrl_rofgwl'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofgwl'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofgwl'//trim(suffix), rc=rc)) then
+             call addmap_from(complnd, 'Flrl_rofgwl'//trim(suffix), comprof, mapconsf, map_fracname_lnd2rof, 'unset')
+             call addmrg_to(comprof, 'Flrl_rofgwl'//trim(suffix), &
+                  mrg_from=complnd, mrg_fld='Flrl_rofgwl'//trim(suffix), &
+                  mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+          end if
        end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to rof: water flux from land (liquid subsurface)
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(complnd, 'Flrl_rofsub')
-       call addfld_to(comprof, 'Flrl_rofsub')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsub', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsub', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_rofsub', comprof, mapconsf, map_fracname_lnd2rof, 'unset')
-          call addmrg_to(comprof, 'Flrl_rofsub', &
-               mrg_from=complnd, mrg_fld='Flrl_rofsub', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd, 'Flrl_rofsub'//trim(suffix))
+          call addfld_to(comprof, 'Flrl_rofsub'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_rofsub'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_rofsub'//trim(suffix), rc=rc)) then
+             call addmap_from(complnd, 'Flrl_rofsub'//trim(suffix), comprof, mapconsf, map_fracname_lnd2rof, 'unset')
+             call addmrg_to(comprof, 'Flrl_rofsub'//trim(suffix), &
+                  mrg_from=complnd, mrg_fld='Flrl_rofsub'//trim(suffix), &
+                  mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+          end if
        end if
-    end if
+    end do
 
     ! ---------------------------------------------------------------------
     ! to rof: irrigation flux from land (withdrawal from rivers)
     ! ---------------------------------------------------------------------
-    if (phase == 'advertise') then
-       call addfld_from(complnd, 'Flrl_irrig')
-       call addfld_to(comprof, 'Flrl_irrig')
-    else
-       if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_irrig', rc=rc) .and. &
-            fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_irrig', rc=rc)) then
-          call addmap_from(complnd, 'Flrl_irrig', comprof, mapconsf, map_fracname_lnd2rof, 'unset')
-          call addmrg_to(comprof, 'Flrl_irrig', &
-               mrg_from=complnd, mrg_fld='Flrl_irrig', mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd, 'Flrl_irrig'//trim(suffix))
+          call addfld_to(comprof, 'Flrl_irrig'//trim(suffix))
+       else
+          if ( fldchk(is_local%wrap%FBImp(complnd, complnd), 'Flrl_irrig'//trim(suffix), rc=rc) .and. &
+               fldchk(is_local%wrap%FBExp(comprof)         , 'Flrl_irrig'//trim(suffix), rc=rc)) then
+             call addmap_from(complnd, 'Flrl_irrig'//trim(suffix), comprof, mapconsf, map_fracname_lnd2rof, 'unset')
+             call addmrg_to(comprof, 'Flrl_irrig'//trim(suffix), &
+                  mrg_from=complnd, mrg_fld='Flrl_irrig'//trim(suffix), &
+                  mrg_type='copy_with_weights', mrg_fracname=mrg_fracname_lnd2rof)
+          end if
        end if
-    end if
+    end do
 
     !=====================================================================
     ! FIELDS TO LAND-ICE (compglc)
@@ -3327,17 +3502,12 @@ contains
     if (phase == 'advertise') then
        call addfld_from(complnd, 'Sl_tsrf_elev')   ! surface temperature of glacier (1->glc_nec+1)
        call addfld_from(complnd, 'Sl_topo_elev')   ! surface heights of glacier     (1->glc_nec+1)
-       call addfld_from(complnd, 'Flgl_qice_elev') ! glacier ice flux               (1->glc_nec+1)
        do ns = 1,is_local%wrap%num_icesheets
           call addfld_to(compglc(ns), 'Sl_tsrf')
-          call addfld_to(compglc(ns), 'Flgl_qice')
        end do
     else
        ! custom mapping, accumulation and merging will be done in prep_glc_mod.F90
        do ns = 1,is_local%wrap%num_icesheets
-          if ( fldchk(is_local%wrap%FBImp(complnd,complnd) , 'Flgl_qice_elev', rc=rc)) then
-             call addmap_from(complnd, 'Flgl_qice_elev', compglc(ns), mapbilnr, map_fracname_lnd2glc, 'unset')
-          end if
           if ( fldchk(is_local%wrap%FBImp(complnd,complnd) , 'Sl_tsrf_elev'  , rc=rc)) then
              call addmap_from(complnd, 'Sl_tsrf_elev', compglc(ns), mapbilnr, map_fracname_lnd2glc, 'unset')
           end if
@@ -3347,6 +3517,25 @@ contains
           end if
        end do
     end if
+    do water_bulk_or_tracers_index = 1, water_bulk_or_tracers_max
+       call set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       if (phase == 'advertise') then
+          call addfld_from(complnd, 'Flgl_qice_elev'//trim(suffix)) ! glacier ice flux (1->glc_nec+1)
+          do ns = 1,is_local%wrap%num_icesheets
+             call addfld_to(compglc(ns), 'Flgl_qice'//trim(suffix))
+          end do
+       else
+          ! custom mapping, accumulation and merging will be done in prep_glc_mod.F90
+          do ns = 1,is_local%wrap%num_icesheets
+             if ( fldchk(is_local%wrap%FBImp(complnd,complnd) , 'Flgl_qice_elev'//trim(suffix), rc=rc)) then
+                call addmap_from(complnd, 'Flgl_qice_elev'//trim(suffix), compglc(ns), &
+                     mapbilnr, map_fracname_lnd2glc, 'unset')
+             end if
+          end do
+       end if
+    end do
 
     !-----------------------------
     ! to glc: from ocn
@@ -3374,5 +3563,34 @@ contains
     end if
 
   end subroutine esmFldsExchange_cesm
+
+  !-----------------------------------------------------------------------------
+  subroutine set_suffix_for_water_bulk_or_tracers(water_bulk_or_tracers_index, suffix, rc)
+
+     ! Set suffix for water fields based on whether water_bulk_or_tracers_index is the
+     ! index for bulk (1) or tracers (2). For tracers, the suffix will be WTRACERS_SUFFIX;
+     ! for bulk, the suffix will be blank.
+
+     use ESMF, only : ESMF_SUCCESS
+
+     ! input/output arguments
+     integer, intent(in) :: water_bulk_or_tracers_index  ! 1 = bulk, 2 = tracers
+     character(len=*), intent(out) :: suffix
+     integer, intent(out) :: rc
+
+     character(len=*), parameter :: subname='(set_suffix_for_water_bulk_or_tracers)'
+     ! ----------------------------------------------
+
+     rc = ESMF_SUCCESS
+
+     select case (water_bulk_or_tracers_index)
+     case (water_bulk_index)
+        suffix = " "
+     case (water_tracers_index)
+        suffix = WTRACERS_SUFFIX
+     case default
+        call shr_log_error(subname//" ERROR: unexpected value for water_bulk_or_tracers_index", rc=rc)
+     end select
+  end subroutine set_suffix_for_water_bulk_or_tracers
 
 end module esmFldsExchange_cesm_mod

--- a/mediator/fd_cesm.yaml
+++ b/mediator/fd_cesm.yaml
@@ -41,32 +41,36 @@
      - standard_name: Faox_evap
        alias: mean_evap_rate_atm_into_ocn
        canonical_units: kg m-2 s-1
-       description: med export - atm/ocn evaporation water flux computed in medidator
+       description: med export - atm/ocn evaporation water flux computed in mediator
+     #
+     - standard_name: Faox_evap_wtracers
+       canonical_units: kg m-2 s-1
+       description: med export - atm/ocn evaporation water tracer flux computed in mediator
      #
      - standard_name: Faox_lat
        alias: mean_laten_heat_flx_atm_into_ocn
        canonical_units: W m-2
-       description: med export - atm/ocn surface latent heat flux computed in medidator
+       description: med export - atm/ocn surface latent heat flux computed in mediator
      #
      - standard_name: Faox_sen
        alias: mean_sensi_heat_flx_atm_into_ocn
        canonical_units: W m-2
-       description: med export - atm/ocn surface sensible heat flux computed in medidator
+       description: med export - atm/ocn surface sensible heat flux computed in mediator
      #
      - standard_name: Faox_lwup
        alias: mean_up_lw_flx_ocn
        canonical_units: W m-2
-       description: med export - ocn long wave radiation flux over the ocean computed in medidator
+       description: med export - ocn long wave radiation flux over the ocean computed in mediator
      #
      - standard_name: Faox_taux
        alias: stress_on_air_ocn_zonal
        canonical_units: N m-2
-       description: med export - atm/ocn zonal surface stress computed in medidator
+       description: med export - atm/ocn zonal surface stress computed in mediator
      #
      - standard_name: Faox_tauy
        alias: stress_on_air_ocn_merid
        canonical_units: N m-2
-       description: med export - atm/ocn meridional surface stress computed in medidator
+       description: med export - atm/ocn meridional surface stress computed in mediator
      #
      - standard_name: Fwxx_taux
        alias: mean_zonal_moment_flx
@@ -83,6 +87,10 @@
      #-----------------------------------
      #
      - standard_name: Fall_evap
+       canonical_units: kg m-2 s-1
+       description: lnd import to med
+     #
+     - standard_name: Fall_evap_wtracers
        canonical_units: kg m-2 s-1
        description: lnd import to med
      #
@@ -166,6 +174,10 @@
        canonical_units: kg kg-1
        description: lnd import to med
      #
+     - standard_name: Sl_qref_wtracers
+       canonical_units: kg kg-1
+       description: lnd import to med
+     #
      - standard_name: Sl_ram1
        canonical_units: s/m
        description: lnd import to med
@@ -186,7 +198,7 @@
        canonical_units: kg m-2 s-1
        description: lnd export to river
      #
-     - standard_name: Flrl_rofdto
+     - standard_name: Flrl_irrig_wtracers
        canonical_units: kg m-2 s-1
        description: lnd export to river
      #
@@ -194,11 +206,23 @@
        canonical_units: kg m-2 s-1
        description: lnd export to river
      #
+     - standard_name: Flrl_rofgwl_wtracers
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
      - standard_name: Flrl_rofi
        canonical_units: kg m-2 s-1
        description: lnd export to river
      #
+     - standard_name: Flrl_rofi_wtracers
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
      - standard_name: Flrl_rofsub
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
+     #
+     - standard_name: Flrl_rofsub_wtracers
        canonical_units: kg m-2 s-1
        description: lnd export to river
      #
@@ -209,6 +233,10 @@
      - standard_name: Flrl_rofsur_nonh2o
        canonical_units: kg m-2 s-1
        description: lnd export to river for non-water liquid tracers
+     #	    
+     - standard_name: Flrl_rofsur_wtracers
+       canonical_units: kg m-2 s-1
+       description: lnd export to river
      #
      - standard_name: Sl_topo_elev
        canonical_units: m
@@ -219,6 +247,10 @@
        description: lnd import to med with elevation classes (1->glc_nec)
      #
      - standard_name: Flgl_qice_elev
+       canonical_units: kg m-2 s-1
+       description: lnd import to med in elevation classes (1->glc_nec)
+     #
+     - standard_name: Flgl_qice_elev_wtracers
        canonical_units: kg m-2 s-1
        description: lnd import to med in elevation classes (1->glc_nec)
      #
@@ -243,6 +275,10 @@
        description: lnd import to med with no elevation classes (computed in med)
      #
      - standard_name: Flgl_qice
+       canonical_units: kg m-2 s-1
+       description: lnd export to med no elevation classes (computed in med)
+     #
+     - standard_name: Flgl_qice_wtracers
        canonical_units: kg m-2 s-1
        description: lnd export to med no elevation classes (computed in med)
      #
@@ -313,11 +349,23 @@
        canonical_units: kg m-2 s-1
        description: atm import to med
      #
+     - standard_name: Faxa_rain_wtracers
+       canonical_units: kg m-2 s-1
+       description: atm import to med
+     #
      - standard_name: Faxa_rainc
        canonical_units: kg m-2 s-1
        description: atm import to med
      #
+     - standard_name: Faxa_rainc_wtracers
+       canonical_units: kg m-2 s-1
+       description: atm import to med
+     #
      - standard_name: Faxa_rainl
+       canonical_units: kg m-2 s-1
+       description: atm import to med
+     #
+     - standard_name: Faxa_rainl_wtracers
        canonical_units: kg m-2 s-1
        description: atm import to med
      #
@@ -326,11 +374,23 @@
        canonical_units: kg m-2 s-1
        description: atm import to med
      #
+     - standard_name: Faxa_snow_wtracers
+       canonical_units: kg m-2 s-1
+       description: atm import to med
+     #
      - standard_name: Faxa_snowc
        canonical_units: kg m-2 s-1
        description: atm import to med
      #
+     - standard_name: Faxa_snowc_wtracers
+       canonical_units: kg m-2 s-1
+       description: atm import to med
+     #
      - standard_name: Faxa_snowl
+       canonical_units: kg m-2 s-1
+       description: atm import to med
+     #
+     - standard_name: Faxa_snowl_wtracers
        canonical_units: kg m-2 s-1
        description: atm import to med
      #
@@ -405,7 +465,11 @@
      - standard_name: Sa_shum
        alias: inst_spec_humid_height_lowest
        canonical_units: kg kg-1
-       description: atm import to med - bottom layer specific humidiaty
+       description: atm import to med - bottom layer specific humidity
+     #
+     - standard_name: Sa_shum_wtracers
+       canonical_units: kg kg-1
+       description: atm import to med - bottom layer tracer specific humidity
      #
      - standard_name: Sa_tbot
        alias: inst_temp_height_lowest
@@ -471,7 +535,11 @@
      #
      - standard_name: Faxx_evap
        canonical_units: kg m-2 s-1
-       description: atm export from meditor - merged water evaporation flux
+       description: atm export from med - merged water evaporation flux
+     #
+     - standard_name: Faxx_evap_wtracers
+       canonical_units: kg m-2 s-1
+       description: atm export from med - merged water tracer evaporation flux
      #
      - standard_name: Faxx_lat
        alias: mean_laten_heat_flx
@@ -517,6 +585,10 @@
        canonical_units: kg kg-1
        description: atm export from med
      #
+     - standard_name: Sx_qref_wtracers
+       canonical_units: kg kg-1
+       description: atm export from med
+     #
      - standard_name: Sx_t
        alias: surface_temperature
        canonical_units: K
@@ -551,15 +623,31 @@
      #
      - standard_name: Fgrg_rofi
        canonical_units: kg m-2 s-1
-       description: glc import tomed - glacier frozen_runoff_flux_to_ocean
+       description: glc import to med - glacier frozen runoff flux to ocean
+     #
+     - standard_name: Fgrg_rofi_wtracers
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier frozen runoff tracer flux to ocean
      #
      - standard_name: Fgrg_rofl
        canonical_units: kg m-2 s-1
        description: glc import to med - glacier liquid runoff flux to ocean
      #
+     - standard_name: Fgrg_rofl_wtracers
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glacier liquid runoff tracer flux to ocean
+     #
+     # Note that Figg_rofi isn't currently implemented in CMEPS, but it is advertised in
+     # CISM, so we still need to include it here. (The intent when this was first
+     # implemented was that this would be an optional, alternative routing of ice runoff
+     # from GLC - a direct creation of icebergs in the ICE model.)
      - standard_name: Figg_rofi
        canonical_units: kg m-2 s-1
-       description: glc import to med - glc frozen runoff_iceberg flux to ice
+       description: glc import to med - glc frozen runoff iceberg flux to ice
+     #
+     - standard_name: Figg_rofi_wtracers
+       canonical_units: kg m-2 s-1
+       description: glc import to med - glc frozen runoff iceberg tracer flux to ice
      #
      - standard_name: Flgg_hflx
        canonical_units: W m-2
@@ -609,6 +697,10 @@
      #
      - standard_name: Faii_evap
        alias: mean_evap_rate_atm_into_ice
+       canonical_units: kg m-2 s-1
+       description: ice import to med
+     #
+     - standard_name: Faii_evap_wtracers
        canonical_units: kg m-2 s-1
        description: ice import to med
      #
@@ -662,6 +754,10 @@
        alias: mean_fresh_water_to_ocean_rate
        canonical_units: kg m-2 s-1
        description: ice import to med to ocean - fresh water to ocean (h2o flux from melting)
+     #
+     - standard_name: Fioi_meltw_wtracers
+       canonical_units: kg m-2 s-1
+       description: ice import to med to ocean - fresh water tracer flux to ocean (h2o flux from melting)
      #
      - standard_name: Fioi_salt
        alias: mean_salt_rate
@@ -739,6 +835,10 @@
        description: ice import to med - ice mask
      #
      - standard_name: Si_qref
+       canonical_units: kg kg-1
+       description: ice import to med
+     #
+     - standard_name: Si_qref_wtracers
        canonical_units: kg kg-1
        description: ice import to med
      #
@@ -872,6 +972,14 @@
        canonical_units: kg kg-1
        description: ocn import to med
      #
+     - standard_name: So_qref_wtracers
+       canonical_units: kg kg-1
+       description: ocn import to med
+     #
+     - standard_name: So_roce_wtracers
+       canonical_units: unitless
+       description: ocn import to med
+     #
      - standard_name: So_re
        canonical_units: 1
        description: ocn import to med
@@ -974,15 +1082,15 @@
      - standard_name: Foxx_evap
        alias: mean_evap_rate
        canonical_units: kg m-2 s-1
-       description: med export to ocn - specific humidity flux
+       description: med export to ocn - evaporation flux
+     #
+     - standard_name: Foxx_evap_wtracers
+       canonical_units: kg m-2 s-1
+       description: med export to ocn - tracer evaporation flux
      #
      - standard_name: Foxx_lat
        canonical_units: W m-2
        description: med export to ocn - latent heat flux into ocean
-     #
-     - standard_name: Foxx_lat
-       canonical_units: W m-2
-       description: med export to ocn - latent heat flux into ocean for HDO
      #
      - standard_name: Foxx_sen
        alias: mean_sensi_heat_flx
@@ -1018,10 +1126,19 @@
        canonical_units: kg m-2 s-1
        description: med export to ocn - water flux due to runoff (frozen)
      #
+     - standard_name: Foxx_rofi_wtracers
+       canonical_units: kg m-2 s-1
+       description: med export to ocn - water tracer flux due to runoff (frozen)
+     #
      - standard_name: Foxx_rofl
        alias: mean_runoff_rate
        canonical_units: kg m-2 s-1
        description: med export to ocn - water flux due to runoff (liquid)
+     #
+     - standard_name: Foxx_rofl_wtracers
+       alias: mean_runoff_rate
+       canonical_units: kg m-2 s-1
+       description: med export to ocn - water tracer flux due to runoff (liquid)
      #
      - standard_name: Foxx_swnet
        alias: mean_net_sw_flx
@@ -1083,13 +1200,25 @@
        canonical_units: kg m-2 s-1
        description: river import to med - water flux due to flooding
      #
+     - standard_name: Flrr_flood_wtracers
+       canonical_units: kg m-2 s-1
+       description: river import to med - water tracer flux due to flooding
+     #
      - standard_name: Flrr_volr
        canonical_units: m
        description: river import to med - river channel total water volume
      #
+     - standard_name: Flrr_volr_wtracers
+       canonical_units: m
+       description: river import to med - river channel total water volume of tracers
+     #
      - standard_name: Flrr_volrmch
        canonical_units: m
        description: river import to med - river channel main channel water volume
+     #
+     - standard_name: Flrr_volrmch_wtracers
+       canonical_units: m
+       description: river import to med - river channel main channel water volume of tracers
      #
      - standard_name: Sr_tdepth
        canonical_units: m
@@ -1103,9 +1232,17 @@
        canonical_units: kg m-2 s-1
        description: river export to ocean - water flux due to runoff (frozen)
      #
+     - standard_name: Forr_rofi_wtracers
+       canonical_units: kg m-2 s-1
+       description: river export to ocean - water tracer flux due to runoff (frozen)
+     #
      - standard_name: Forr_rofi_glc
        canonical_units: kg m-2 s-1
        description: river export to ocean - water flux due to runoff originating from glc (frozen)
+     #
+     - standard_name: Forr_rofi_glc_wtracers
+       canonical_units: kg m-2 s-1
+       description: river export to ocean - water tracer flux due to runoff originating from glc (frozen)
      #
      - standard_name: Forr_rofl
        canonical_units: kg m-2 s-1
@@ -1115,6 +1252,10 @@
        canonical_units: kg m-2 s-1
        description: river import to med - non-water flux due to runoff
      #
+     - standard_name: Forr_rofl_wtracers
+       canonical_units: kg m-2 s-1
+       description: river import to med - water tracer flux due to runoff (liquid)
+     #
      - standard_name: Forr_rofl_glc
        canonical_units: kg m-2 s-1
        description: river import to med - water flux due to runoff originating from glc (liquid)
@@ -1122,6 +1263,10 @@
      - standard_name: Forr_rofl_nonh2o
        canonical_units: kg m-2 s-1
        description: river import to med - non-water flux(es) due to runoff originating from lnd (liquid)
+     #
+     - standard_name: Forr_rofl_glc_wtracers
+       canonical_units: kg m-2 s-1
+       description: river import to med - water tracer flux due to runoff originating from glc (liquid)
      #
      #-----------------------------------
      # section: wav import to med

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -680,7 +680,7 @@ contains
     use NUOPC , only : NUOPC_CompAttributeGet, NUOPC_CompAttributeSet, NUOPC_CompAttributeAdd
     use esmFlds, only : med_fldlist_init1, med_fld_GetFldInfo, med_fldList_entry_type
     use med_phases_history_mod, only : med_phases_history_init
-    use med_methods_mod       , only : mediator_checkfornans
+    use med_methods_mod       , only : mediator_checkfornans, water_tracers_do_checks
 
     ! input/output variables
     type(ESMF_GridComp)  :: gcomp
@@ -961,6 +961,19 @@ contains
           write(logunit,*) ' Fields will NOT be checked for NaN values when passed from mediator to component'
        endif
     endif
+
+    ! Should mediator check water tracer consistency?
+    call NUOPC_CompAttributeGet(gcomp, name="water_tracers_do_checks", value=cvalue, &
+         isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+       read(cvalue, *) water_tracers_do_checks
+    else
+       water_tracers_do_checks = .false.
+    endif
+    if(maintask) then
+       write(logunit,*) ' water_tracers_do_checks is ',water_tracers_do_checks
+    end if
 
     ! Should target component use all data for first time step?
     do ncomp = 1,ncomps

--- a/mediator/med_field_info_mod.F90
+++ b/mediator/med_field_info_mod.F90
@@ -11,7 +11,7 @@ module med_field_info_mod
   use ESMF            , only : ESMF_FieldCreate, ESMF_FieldGet
   use med_utils_mod   , only : ChkErr => med_utils_ChkErr
   use shr_log_mod     , only : shr_log_error
-  use wtracers_mod    , only : wtracers_is_wtracer_field
+  use wtracers_mod    , only : wtracers_is_wtracer_field, wtracers_get_num_tracers
 
   implicit none
   private
@@ -167,7 +167,7 @@ contains
     !
     ! It is assumed that fields generally have no ungridded dimensions. However, for
     ! fields ending with the water tracer suffix, it is instead assumed that they have a
-    ! single ungridded dimension of size given by shr_wtracers_get_num_tracers.
+    ! single ungridded dimension of size given by wtracers_get_num_tracers.
     !
     ! field_info_array is allocated here (and, since it has intent(out), it is
     ! automatically deallocated if it is already allocated on entry to this subroutine)
@@ -188,14 +188,18 @@ contains
 
     n_fields = size(field_names)
     allocate(field_info_array(n_fields))
-    ! For now, hard-code n_tracers, since we haven't set up the tracer information; we'll
-    ! fix this in an upcoming set of changes
-    n_tracers = 0
 
     do i = 1, n_fields
        is_tracer = wtracers_is_wtracer_field(field_names(i))
        if (is_tracer) then
-          ! Field is a water tracer; assume a single ungridded dimension
+          ! Field is a water tracer; assume a single ungridded dimension.
+          !
+          ! Note that wtracers_get_num_tracers will return the same value for all water
+          ! tracers. However, we call this inside the loop - and in particular, inside the
+          ! is_tracer conditional - to avoid trying to retrieve this value in the
+          ! situation where there aren't any water tracers and the water tracer module
+          ! hasn't been initialized. (This may never occur in practice, but it might.)
+          n_tracers = wtracers_get_num_tracers()
           field_info_array(i) = med_field_info_create_directly( &
                name=field_names(i), &
                ungridded_lbound=[1], &

--- a/mediator/med_io_mod.F90
+++ b/mediator/med_io_mod.F90
@@ -40,6 +40,8 @@ module med_io_mod
 
   ! private member functions
   private :: med_io_file_exists
+  private :: med_io_def_var_with_atts
+  private :: med_io_read_1d_var
 
   ! public data members:
   interface med_io_read
@@ -740,7 +742,6 @@ contains
     integer(kind=Pio_Offset_Kind) :: frame
     character(CL)                 :: itemc       ! string converted to char
     character(CL)                 :: name1       ! var name
-    character(CL)                 :: cunit       ! var units
     character(CL)                 :: lpre        ! local prefix
     character(CS)                 :: coordvarnames(2)   ! coordinate variable names
     character(CS)                 :: coordnames(2)      ! coordinate long names
@@ -762,6 +763,7 @@ contains
     type(ESMF_Field)              :: lfield
     integer                       :: rank
     logical                       :: tiles
+    logical                       :: ltavg
     character(CL), allocatable    :: fieldNameList(:)
 
     ! For a single ungridded dimension, there will be 1 element in ungriddedUBound and 1
@@ -781,6 +783,8 @@ contains
     if (present(pre)) lpre = trim(pre)
     luse_float = .false.
     if (present(use_float)) luse_float = use_float
+    ltavg = .false.
+    if (present(tavg)) ltavg = tavg
 
     tiles = .false.
     if (present(ntile)) then
@@ -956,25 +960,8 @@ contains
                       write(cnumber,'(i0)') n
                       write(cnumber2,'(i0)') n2
                       name1 = trim(lpre)//'_'//trim(itemc)//trim(cnumber)//'_'//trim(cnumber2)
-                      call ESMF_LogWrite(trim(subname)//': defining '//trim(name1), ESMF_LOGMSG_INFO)
-                      if (luse_float) then
-                         rcode = pio_def_var(io_file, trim(name1), PIO_REAL, dimid, varid)
-                         rcode = pio_put_att(io_file, varid,"_FillValue",real(lfillvalue,r4))
-                      else
-                         rcode = pio_def_var(io_file, trim(name1), PIO_DOUBLE, dimid, varid)
-                         rcode = pio_put_att(io_file,varid,"_FillValue",lfillvalue)
-                      end if
-                      if (NUOPC_FieldDictionaryHasEntry(trim(itemc))) then
-                         call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
-                         if (chkerr(rc,__LINE__,u_FILE_u)) return
-                         rcode = pio_put_att(io_file, varid, "units", trim(cunit))
-                      end if
-                      rcode = pio_put_att(io_file, varid, "standard_name", trim(name1))
-                      if (present(tavg)) then
-                         if (tavg) then
-                            rcode = pio_put_att(io_file, varid, "cell_methods", "time: mean")
-                         endif
-                      endif
+                      call med_io_def_var_with_atts(io_file, name1, itemc, dimid, luse_float, lfillvalue, ltavg, rc)
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
                    end do
                 end do
              else if (rank == 2) then
@@ -989,48 +976,14 @@ contains
                    if (trim(itemc) /= "hgt") then
                       write(cnumber,'(i0)') n
                       name1 = trim(lpre)//'_'//trim(itemc)//trim(cnumber)
-                      call ESMF_LogWrite(trim(subname)//': defining '//trim(name1), ESMF_LOGMSG_INFO)
-                      if (luse_float) then
-                         rcode = pio_def_var(io_file, trim(name1), PIO_REAL, dimid, varid)
-                         rcode = pio_put_att(io_file, varid,"_FillValue",real(lfillvalue,r4))
-                      else
-                         rcode = pio_def_var(io_file, trim(name1), PIO_DOUBLE, dimid, varid)
-                         rcode = pio_put_att(io_file,varid,"_FillValue",lfillvalue)
-                      end if
-                      if (NUOPC_FieldDictionaryHasEntry(trim(itemc))) then
-                         call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
-                         if (chkerr(rc,__LINE__,u_FILE_u)) return
-                         rcode = pio_put_att(io_file, varid, "units", trim(cunit))
-                      end if
-                      rcode = pio_put_att(io_file, varid, "standard_name", trim(name1))
-                      if (present(tavg)) then
-                         if (tavg) then
-                            rcode = pio_put_att(io_file, varid, "cell_methods", "time: mean")
-                         endif
-                      endif
+                      call med_io_def_var_with_atts(io_file, name1, itemc, dimid, luse_float, lfillvalue, ltavg, rc)
+                      if (chkerr(rc,__LINE__,u_FILE_u)) return
                    end if
                 end do
              else if (rank == 1) then
                 name1 = trim(lpre)//'_'//trim(itemc)
-                call ESMF_LogWrite(trim(subname)//': defining '//trim(name1), ESMF_LOGMSG_INFO)
-                if (luse_float) then
-                   rcode = pio_def_var(io_file, trim(name1), PIO_REAL, dimid, varid)
-                   rcode = pio_put_att(io_file, varid,"_FillValue",real(lfillvalue,r4))
-                else
-                   rcode = pio_def_var(io_file, trim(name1), PIO_DOUBLE, dimid, varid)
-                   rcode = pio_put_att(io_file,varid,"_FillValue",lfillvalue)
-                end if
-                if (NUOPC_FieldDictionaryHasEntry(trim(itemc))) then
-                   call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
-                   if (chkerr(rc,__LINE__,u_FILE_u)) return
-                   rcode = pio_put_att(io_file, varid, "units", trim(cunit))
-                end if
-                rcode = pio_put_att(io_file, varid, "standard_name", trim(name1))
-                if (present(tavg)) then
-                   if (tavg) then
-                      rcode = pio_put_att(io_file, varid, "cell_methods", "time: mean")
-                   endif
-                endif
+                call med_io_def_var_with_atts(io_file, name1, itemc, dimid, luse_float, lfillvalue, ltavg, rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
              else
                 call shr_log_error(subname//' ERROR: unhandled rank', line=__LINE__, file=u_FILE_u, rc=rc)
                 return
@@ -1547,11 +1500,10 @@ contains
     use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
     use ESMF , only : ESMF_FieldBundleIsCreated, ESMF_FieldBundleGet
     use ESMF , only : ESMF_FieldGet, ESMF_MeshGet, ESMF_DistGridGet
-    use pio  , only : file_desc_T, var_desc_t, io_desc_t, pio_nowrite, pio_openfile
-    use pio  , only : pio_noerr, PIO_BCAST_ERROR, PIO_INTERNAL_ERROR
-    use pio  , only : pio_inq_varid
-    use pio  , only : pio_double, pio_get_att, pio_seterrorhandling, pio_freedecomp, pio_closefile
-    use pio  , only : pio_read_darray, pio_offset_kind, pio_setframe
+    use pio  , only : file_desc_T, io_desc_t, pio_nowrite, pio_openfile
+    use pio  , only : PIO_BCAST_ERROR, PIO_INTERNAL_ERROR
+    use pio  , only : pio_seterrorhandling, pio_freedecomp, pio_closefile
+    use pio  , only : pio_offset_kind
 
     ! input/output arguments
     character(len=*)                        ,intent(in)  :: filename
@@ -1565,14 +1517,12 @@ contains
     type(ESMF_Field)              :: lfield
     integer                       :: rcode
     integer                       :: nf
-    integer                       :: k,n,n2,l
+    integer                       :: k,n,n2
     type(file_desc_t)             :: pioid
-    type(var_desc_t)              :: varid
     type(io_desc_t)               :: iodesc
     character(CL)                 :: itemc       ! string converted to char
     character(CL)                 :: name1       ! var name
     character(CL)                 :: lpre        ! local prefix
-    real(r8)                      :: lfillvalue
     integer                       :: rank, lsize
     real(r8), pointer             :: fldptr1(:), fldptr1_tmp(:)
     real(r8), pointer             :: fldptr2(:,:)
@@ -1698,23 +1648,8 @@ contains
                 write(cnumber,'(i0)') n
                 write(cnumber2,'(i0)') n2
                 name1 = trim(lpre)//'_'//trim(itemc)//trim(cnumber)//'_'//trim(cnumber2)
-
-                rcode = pio_inq_varid(pioid, trim(name1), varid)
-                if (rcode == pio_noerr) then
-                   call ESMF_LogWrite(trim(subname)//' read field '//trim(name1), ESMF_LOGMSG_INFO)
-                   if (chkerr(rc,__LINE__,u_FILE_u)) return
-                   call pio_setframe(pioid, varid, lframe)
-                   call pio_read_darray(pioid, varid, iodesc, fldptr1_tmp, rcode)
-                   rcode = pio_get_att(pioid, varid, "_FillValue", lfillvalue)
-                   if (rcode /= pio_noerr) then
-                      lfillvalue = fillvalue
-                   endif
-                   do l = 1,size(fldptr1_tmp)
-                      if (fldptr1_tmp(l) == lfillvalue) fldptr1_tmp(l) = 0.0_r8
-                   enddo
-                else
-                   fldptr1_tmp = 0.0_r8
-                endif
+                call med_io_read_1d_var(pioid, name1, iodesc, lframe, fldptr1_tmp, rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
                 fldptr3(n,n2,:) = fldptr1_tmp(:)
              end do
           end do
@@ -1742,23 +1677,8 @@ contains
              ! ungridded dimension index of the field bundle 2d field
              write(cnumber,'(i0)') n
              name1 = trim(lpre)//'_'//trim(itemc)//trim(cnumber)
-
-             rcode = pio_inq_varid(pioid, trim(name1), varid)
-             if (rcode == pio_noerr) then
-                call ESMF_LogWrite(trim(subname)//' read field '//trim(name1), ESMF_LOGMSG_INFO)
-                if (chkerr(rc,__LINE__,u_FILE_u)) return
-                call pio_setframe(pioid, varid, lframe)
-                call pio_read_darray(pioid, varid, iodesc, fldptr1_tmp, rcode)
-                rcode = pio_get_att(pioid, varid, "_FillValue", lfillvalue)
-                if (rcode /= pio_noerr) then
-                   lfillvalue = fillvalue
-                endif
-                do l = 1,size(fldptr1_tmp)
-                   if (fldptr1_tmp(l) == lfillvalue) fldptr1_tmp(l) = 0.0_r8
-                enddo
-             else
-                fldptr1_tmp = 0.0_r8
-             endif
+             call med_io_read_1d_var(pioid, name1, iodesc, lframe, fldptr1_tmp, rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (gridToFieldMap(1) == 1) then
                 fldptr2(:,n) = fldptr1_tmp(:)
              else if (gridToFieldMap(1) == 2) then
@@ -1770,23 +1690,8 @@ contains
 
        else if (rank == 1) then
           name1 = trim(lpre)//'_'//trim(itemc)
-
-          rcode = pio_inq_varid(pioid, trim(name1), varid)
-          if (rcode == pio_noerr) then
-             call ESMF_LogWrite(trim(subname)//' read field '//trim(name1), ESMF_LOGMSG_INFO)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             call pio_setframe(pioid,varid,lframe)
-             call pio_read_darray(pioid, varid, iodesc, fldptr1, rcode)
-             rcode = pio_get_att(pioid,varid,"_FillValue",lfillvalue)
-             if (rcode /= pio_noerr) then
-                lfillvalue = fillvalue
-             endif
-             do n = 1,size(fldptr1)
-                if (fldptr1(n) == lfillvalue) fldptr1(n) = 0.0_r8
-             enddo
-          else
-             fldptr1 = 0.0_r8
-          endif
+          call med_io_read_1d_var(pioid, name1, iodesc, lframe, fldptr1, rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
        end if
 
     enddo ! end of loop over fields
@@ -2261,5 +2166,101 @@ contains
     date = abs(year)*10000_I8 + month*100 + day  ! coded calendar date
     if (year < 0) date = -date
   end subroutine med_io_ymd2date_long
+
+  !===============================================================================
+  subroutine med_io_def_var_with_atts(io_file, name1, itemc, dimid, luse_float, lfillvalue, ltavg, rc)
+
+    !---------------
+    ! Define a netcdf variable and set its standard attributes
+    !---------------
+
+    use pio  , only : var_desc_t, pio_real, pio_double, pio_def_var, pio_put_att
+
+    ! input/output variables
+    type(file_desc_t)          , intent(inout) :: io_file
+    character(len=*)           , intent(in)    :: name1
+    character(len=*)           , intent(in)    :: itemc
+    integer, pointer           , intent(in)    :: dimid(:)
+    logical                    , intent(in)    :: luse_float
+    real(r8)                   , intent(in)    :: lfillvalue
+    logical                    , intent(in)    :: ltavg
+    integer                    , intent(out)   :: rc
+
+    ! local variables
+    type(var_desc_t) :: varid
+    integer          :: rcode
+    character(CL)    :: cunit  ! var units
+    character(*),parameter :: subName = '(med_io_def_var_with_atts) '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    call ESMF_LogWrite(trim(subname)//': defining '//trim(name1), ESMF_LOGMSG_INFO)
+    if (luse_float) then
+       rcode = pio_def_var(io_file, trim(name1), PIO_REAL, dimid, varid)
+       rcode = pio_put_att(io_file, varid, "_FillValue", real(lfillvalue, r4))
+    else
+       rcode = pio_def_var(io_file, trim(name1), PIO_DOUBLE, dimid, varid)
+       rcode = pio_put_att(io_file, varid, "_FillValue", lfillvalue)
+    end if
+    if (NUOPC_FieldDictionaryHasEntry(trim(itemc))) then
+       call NUOPC_FieldDictionaryGetEntry(itemc, canonicalUnits=cunit, rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       rcode = pio_put_att(io_file, varid, "units", trim(cunit))
+    end if
+    rcode = pio_put_att(io_file, varid, "standard_name", trim(name1))
+    if (ltavg) then
+       rcode = pio_put_att(io_file, varid, "cell_methods", "time: mean")
+    end if
+
+  end subroutine med_io_def_var_with_atts
+
+  !===============================================================================
+  subroutine med_io_read_1d_var(pioid, name1, iodesc, lframe, fldptr, rc)
+
+    !---------------
+    ! Read a 1-d variable from a netcdf file, replacing fill values with 0.
+    ! If the variable is not found, the array is zeroed.
+    !---------------
+
+    use ESMF , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
+    use pio  , only : var_desc_t, io_desc_t, pio_noerr, pio_offset_kind
+    use pio  , only : pio_inq_varid, pio_setframe, pio_read_darray, pio_get_att
+
+    ! input/output variables
+    type(file_desc_t)             , intent(inout) :: pioid
+    character(len=*)              , intent(in)    :: name1
+    type(io_desc_t)               , intent(inout) :: iodesc
+    integer(kind=PIO_OFFSET_KIND) , intent(in)    :: lframe
+    real(r8)                      , intent(inout) :: fldptr(:)
+    integer                       , intent(out)   :: rc
+
+    ! local variables
+    type(var_desc_t) :: varid
+    integer          :: rcode, l
+    real(r8)         :: lfillvalue
+    character(*),parameter :: subName = '(med_io_read_1d_var) '
+    !-------------------------------------------------------------------------------
+
+    rc = ESMF_SUCCESS
+
+    rcode = pio_inq_varid(pioid, trim(name1), varid)
+    if (rcode == pio_noerr) then
+       call ESMF_LogWrite(trim(subname)//' read field '//trim(name1), ESMF_LOGMSG_INFO)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       call pio_setframe(pioid, varid, lframe)
+       call pio_read_darray(pioid, varid, iodesc, fldptr, rcode)
+       rcode = pio_get_att(pioid, varid, "_FillValue", lfillvalue)
+       if (rcode /= pio_noerr) then
+          lfillvalue = fillvalue
+       endif
+       do l = 1,size(fldptr)
+          if (fldptr(l) == lfillvalue) fldptr(l) = 0.0_r8
+       enddo
+    else
+       fldptr = 0.0_r8
+    endif
+
+  end subroutine med_io_read_1d_var
 
 end module med_io_mod

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -33,7 +33,8 @@ module med_methods_mod
   end interface med_methods_check_for_nans
 
   ! used/reused in module
-  logical, public               :: mediator_checkfornans  ! set in med.F90 AdvertiseFields
+  logical, public               :: mediator_checkfornans   ! set in med.F90 AdvertiseFields
+  logical, public               :: water_tracers_do_checks ! set in med.F90 AdvertiseFields
   logical                       :: isPresent
   character(len=1024)           :: msgString
   type(ESMF_FieldStatus_Flag)   :: status
@@ -60,6 +61,7 @@ module med_methods_mod
   public med_methods_FB_getdata3d
   public med_methods_FB_getmesh
   public med_methods_FB_check_for_nans
+  public med_methods_FB_check_wtracers
 
   public med_methods_State_reset
   public med_methods_State_diagnose
@@ -1147,6 +1149,7 @@ contains
 
     ! local variables
     character(len=CS) :: lstring
+    character(len=CL) :: msg
     real(R8), pointer :: dataPtr1d(:)
     real(R8), pointer :: dataPtr2d(:,:)
     real(R8), pointer :: dataPtr3d(:,:,:)
@@ -1197,7 +1200,8 @@ contains
           write(msgString,'(A,a)') trim(subname)//' '//trim(lstring)//': '//trim(fieldname)," no data"
        endif
     else
-       call shr_log_error(subname//": ERROR: unhandled field rank", &
+       write(msg,'(a,i0)') subname//": ERROR: unhandled field rank ", fieldrank
+       call shr_log_error(msg, &
             line=__LINE__, file=u_FILE_u, rc=rc)
        return
     end if
@@ -2653,6 +2657,7 @@ contains
     integer                     :: nancount
     character(len=CS)           :: nancount_char
     character(len=CL)           :: msg_error
+    character(len=CL)           :: msg
     logical                     :: nanfound
     character(len=*), parameter :: subname='(med_methods_FB_check_for_nans)'
     ! ----------------------------------------------
@@ -2685,7 +2690,8 @@ contains
           if (chkerr(rc,__LINE__,u_FILE_u)) return
           call med_methods_check_for_nans(dataptr3d, nancount)
        else
-          call shr_log_error(subname//": ERROR: unhandled field rank", &
+          write(msg,'(a,i0)') subname//": ERROR: unhandled field rank ", fieldrank
+          call shr_log_error(msg, &
                line=__LINE__, file=u_FILE_u, rc=rc)
           return
        end if
@@ -2757,5 +2763,120 @@ contains
        end do
     end do
   end subroutine med_methods_check_for_nans_3d
+
+  !-----------------------------------------------------------------------------
+  subroutine med_methods_FB_check_wtracers(FB, rc)
+
+    ! ----------------------------------------------
+    ! Check all water tracer fields in FB for consistency with their non-water-tracer
+    ! counterparts
+    !
+    ! Aborts if any inconsistencies are found
+    !
+    ! Should only be called in simulations set up to maintain constant water tracer
+    ! ratios: in general, water tracers will deviate from their initial, fixed ratios, and
+    ! so it makes no sense to perform these checks since they will always fail.
+    ! ----------------------------------------------
+
+    use wtracers_mod, only : wtracers_get_bulk_fieldname, wtracers_check_tracer_ratios
+    use ESMF, only : ESMF_FieldBundle, ESMF_Field
+    use ESMF, only : ESMF_FieldBundleGet, ESMF_FieldGet
+
+    ! input/output arguments
+    type(ESMF_FieldBundle), intent(in) :: FB
+    integer, intent(out) :: rc
+
+    ! local variables
+    integer :: fieldCount
+    character(ESMF_MAXSTR), allocatable :: fieldNameList(:)
+    character(ESMF_MAXSTR) :: fieldNameNonTracer
+    character(ESMF_MAXSTR) :: FBName
+    integer :: n
+    integer :: fieldrank
+    logical :: hasSuffix
+    logical :: isPresentNonTracer
+    type(ESMF_Field) :: fieldTracers
+    type(ESMF_Field) :: fieldNonTracer
+
+    ! For 1-d bulk arrays:
+    real(r8), pointer :: dataTracers2d(:,:)  ! dimensioned [tracerNum, gridcell]
+    real(r8), pointer :: dataNonTracer1d(:)  ! dimensioned [gridcell]
+
+    ! For 2-d bulk arrays:
+    real(r8), pointer :: dataTracers3d(:,:,:) ! dimensioned [ungriddedDim, tracerNum, gridcell]
+    real(r8), pointer :: dataNonTracer2d(:,:) ! dimensioned [ungriddedDim, gridcell]
+
+    character(len=CL) :: msg
+    character(len=*), parameter :: subname='(med_methods_FB_check_wtracers)'
+    ! ----------------------------------------------
+    rc = ESMF_SUCCESS
+
+    if (.not. water_tracers_do_checks) return
+
+    call ESMF_FieldBundleGet(FB, name=FBName, fieldCount=fieldCount, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    allocate(fieldNameList(fieldCount))
+    call ESMF_FieldBundleGet(FB, fieldNameList=fieldNameList, rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+    if (dbug_flag > 5) then
+       call ESMF_LogWrite(trim(subname)//": Checking FB: "//trim(FBName), ESMF_LOGMSG_INFO)
+    end if
+
+    do n = 1, fieldCount
+       call wtracers_get_bulk_fieldname( &
+            fieldname=fieldNameList(n), &
+            is_wtracer_field=hasSuffix, &
+            bulk_fieldname=fieldNameNonTracer)
+       if (hasSuffix) then
+          call ESMF_FieldBundleGet(FB, fieldName=fieldNameNonTracer, isPresent=isPresentNonTracer, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          if (isPresentNonTracer) then
+             if (dbug_flag > 5) then
+                call ESMF_LogWrite(trim(subname)//": Checking <" // trim(fieldNameList(n)) // &
+                     "> against <" // trim(fieldNameNonTracer) // ">", &
+                     ESMF_LOGMSG_INFO)
+             end if
+
+             call ESMF_FieldBundleGet(FB, fieldName=fieldNameList(n), field=fieldTracers, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call ESMF_FieldBundleGet(FB, fieldName=fieldNameNonTracer, field=fieldNonTracer, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+             call ESMF_FieldGet(fieldNonTracer, rank=fieldrank, rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+             if (fieldrank == 1) then
+                call ESMF_FieldGet(fieldTracers, farrayPtr=dataTracers2d, rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+                call ESMF_FieldGet(fieldNonTracer, farrayPtr=dataNonTracer1d, rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+                call wtracers_check_tracer_ratios(dataTracers2d, dataNonTracer1d, &
+                     trim(FBName)//":"//trim(fieldNameList(n)))
+             else if (fieldrank == 2) then
+                call ESMF_FieldGet(fieldTracers, farrayPtr=dataTracers3d, rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+                call ESMF_FieldGet(fieldNonTracer, farrayPtr=dataNonTracer2d, rc=rc)
+                if (chkerr(rc,__LINE__,u_FILE_u)) return
+                call wtracers_check_tracer_ratios(dataTracers3d, dataNonTracer2d, &
+                     trim(FBName)//":"//trim(fieldNameList(n)))
+             else
+                write(msg,'(a,i0)') subname//": ERROR: unhandled field rank ", fieldrank
+                call shr_log_error(msg, &
+                     line=__LINE__, file=u_FILE_u, rc=rc)
+                return
+             end if
+          else
+             ! This is the situation for a small number of fields where we have a tracer
+             ! field without a corresponding non-tracer field.
+             if (dbug_flag > 5) then
+                call ESMF_LogWrite(trim(subname)//": Skipping check for <" // trim(fieldNameList(n)) // &
+                     "> which has no corresponding non-tracer field", ESMF_LOGMSG_INFO)
+             end if
+          end if
+       end if
+    end do
+
+  end subroutine med_methods_FB_check_wtracers
 
 end module med_methods_mod

--- a/mediator/med_phases_post_atm_mod.F90
+++ b/mediator/med_phases_post_atm_mod.F90
@@ -33,6 +33,7 @@ contains
     use med_map_mod           , only : med_map_field_packed
     use med_constants_mod     , only : dbug_flag => med_constants_dbug_flag
     use med_utils_mod         , only : chkerr    => med_utils_ChkErr
+    use med_methods_mod       , only : med_methods_FB_check_wtracers
     use med_internalstate_mod , only : compocn, compatm, compice, complnd, compwav
     use perf_mod              , only : t_startf, t_stopf
 
@@ -57,6 +58,11 @@ contains
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBImp(compatm,compatm), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! map atm to ocn
     if (is_local%wrap%med_coupling_active(compatm,compocn)) then

--- a/mediator/med_phases_post_glc_mod.F90
+++ b/mediator/med_phases_post_glc_mod.F90
@@ -24,6 +24,7 @@ module med_phases_post_glc_mod
   use med_methods_mod       , only : fldbun_getdata2d => med_methods_FB_getdata2d
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
   use med_methods_mod       , only : field_getdata2d  => med_methods_Field_getdata2d
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_utils_mod         , only : chkerr           => med_utils_ChkErr
   use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
   use med_map_mod           , only : med_map_rh_is_created, med_map_routehandles_init
@@ -150,6 +151,13 @@ contains
           end if
        end if
     end if
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    do ns = 1,is_local%wrap%num_icesheets
+       call med_methods_FB_check_wtracers(is_local%wrap%FBImp(compglc(ns),compglc(ns)), rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end do
 
     !---------------------------------------
     ! glc->rof mapping

--- a/mediator/med_phases_post_ice_mod.F90
+++ b/mediator/med_phases_post_ice_mod.F90
@@ -26,6 +26,7 @@ contains
     use med_constants_mod     , only : dbug_flag   => med_constants_dbug_flag
     use med_utils_mod         , only : chkerr      => med_utils_ChkErr
     use med_methods_mod       , only : FB_diagnose => med_methods_FB_diagnose
+    use med_methods_mod       , only : med_methods_FB_check_wtracers
     use med_map_mod           , only : med_map_field_packed
     use med_fraction_mod      , only : med_fraction_set
     use med_internalstate_mod , only : InternalState
@@ -54,6 +55,11 @@ contains
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBImp(compice,compice), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! update ice fraction
     call med_fraction_set(gcomp, rc)

--- a/mediator/med_phases_post_lnd_mod.F90
+++ b/mediator/med_phases_post_lnd_mod.F90
@@ -22,6 +22,7 @@ contains
     use med_constants_mod       , only : dbug_flag   => med_constants_dbug_flag
     use med_utils_mod           , only : chkerr      => med_utils_ChkErr
     use med_methods_mod         , only : FB_diagnose => med_methods_FB_diagnose
+    use med_methods_mod         , only : med_methods_FB_check_wtracers
     use med_map_mod             , only : med_map_field_packed
     use med_internalstate_mod   , only : InternalState
     use med_phases_prep_rof_mod , only : med_phases_prep_rof_accum
@@ -51,6 +52,11 @@ contains
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBImp(complnd,complnd), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     call NUOPC_MediatorGet(gcomp, driverClock=dClock, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/mediator/med_phases_post_ocn_mod.F90
+++ b/mediator/med_phases_post_ocn_mod.F90
@@ -30,6 +30,7 @@ contains
     use med_internalstate_mod   , only : compice, compocn, compwav
     use med_phases_history_mod  , only : med_phases_history_write_comp
     use med_phases_prep_glc_mod , only : med_phases_prep_glc_accum_ocn
+    use med_methods_mod         , only : med_methods_FB_check_wtracers
     use perf_mod                , only : t_startf, t_stopf
 
     ! input/output variables
@@ -53,6 +54,11 @@ contains
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBImp(compocn,compocn), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Map ocn->ice
     if (is_local%wrap%med_coupling_active(compocn,compice)) then

--- a/mediator/med_phases_post_rof_mod.F90
+++ b/mediator/med_phases_post_rof_mod.F90
@@ -22,6 +22,7 @@ module med_phases_post_rof_mod
   use med_methods_mod       , only : fldbun_copy => med_methods_FB_copy
   use med_methods_mod       , only : fldbun_getdata1d => med_methods_FB_getdata1d
   use med_methods_mod       , only : fldbun_getmesh   => med_methods_FB_getmesh
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_field_info_mod    , only : med_field_info_type, med_field_info_create_from_field
   use med_field_info_mod    , only : med_field_info_esmf_fieldcreate
   use perf_mod              , only : t_startf, t_stopf
@@ -135,6 +136,11 @@ contains
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBImp(comprof,comprof), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     do n = 1, num_rof_fields
       call fldbun_copy(FBrof_r, is_local%wrap%FBImp(comprof,comprof), rc=rc)

--- a/mediator/med_phases_post_wav_mod.F90
+++ b/mediator/med_phases_post_wav_mod.F90
@@ -22,6 +22,7 @@ contains
     use med_constants_mod     , only : dbug_flag   => med_constants_dbug_flag
     use med_utils_mod         , only : chkerr      => med_utils_ChkErr
     use med_methods_mod       , only : FB_diagnose => med_methods_FB_diagnose
+    use med_methods_mod       , only : med_methods_FB_check_wtracers
     use med_map_mod           , only : med_map_field_packed
     use med_internalstate_mod , only : InternalState
     use med_internalstate_mod , only : compwav, compatm, compocn, compice
@@ -49,6 +50,11 @@ contains
     nullify(is_local%wrap)
     call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBImp(compwav,compwav), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! map wav to atm
     if (is_local%wrap%med_coupling_active(compwav,compatm)) then

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -15,6 +15,7 @@ module med_phases_prep_atm_mod
   use med_methods_mod       , only : FB_fldchk   => med_methods_FB_FldChk
   use med_methods_mod       , only : FB_getfldptr=> med_methods_FB_GetFldPtr
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_merge_mod         , only : med_merge_auto
   use med_map_mod           , only : med_map_field_packed
   use med_internalstate_mod , only : InternalState, maintask, logunit, samegrid_atmlnd
@@ -255,6 +256,11 @@ contains
     ! Check for nans in fields export to atm
     call FB_check_for_nans(is_local%wrap%FBExp(compatm), maintask, logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBExp(compatm), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -29,21 +29,27 @@ module med_phases_prep_glc_mod
   use med_constants_mod     , only : czero            => med_constants_czero
   use med_constants_mod     , only : shr_const_pi, shr_const_spval
   use med_methods_mod       , only : fldbun_getmesh   => med_methods_FB_getmesh
+  use med_methods_mod       , only : fldbun_getdata3d => med_methods_FB_getdata3d
   use med_methods_mod       , only : fldbun_getdata2d => med_methods_FB_getdata2d
   use med_methods_mod       , only : fldbun_getdata1d => med_methods_FB_getdata1d
   use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
   use med_methods_mod       , only : fldbun_reset     => med_methods_FB_reset
   use med_methods_mod       , only : fldbun_init      => med_methods_FB_init
+  use med_methods_mod       , only : fldbun_accum     => med_methods_FB_accum
+  use med_methods_mod       , only : fldbun_average   => med_methods_FB_average
+  use med_methods_mod       , only : fldbun_copy      => med_methods_FB_copy
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
   use med_methods_mod       , only : field_getdata2d  => med_methods_Field_getdata2d
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
   use med_methods_mod       , only : fldchk           => med_methods_FB_FldChk
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_field_info_mod    , only : med_field_info_type, med_field_info_array_from_state
   use med_utils_mod         , only : chkerr           => med_utils_ChkErr
   use nuopc_shr_methods     , only : alarmInit
   use glc_elevclass_mod     , only : glc_get_num_elevation_classes
   use glc_elevclass_mod     , only : glc_get_elevation_classes
   use glc_elevclass_mod     , only : glc_get_fractional_icecov
+  use wtracers_mod          , only : wtracers_present, wtracers_get_num_tracers, WTRACERS_SUFFIX
   use perf_mod              , only : t_startf, t_stopf
   use shr_log_mod           , only : shr_log_error
 
@@ -58,6 +64,9 @@ module med_phases_prep_glc_mod
 
   private :: med_phases_prep_glc_map_lnd2glc
   private :: med_phases_prep_glc_renormalize_smb
+  private :: renormalize_smb_accumulate_sums_l
+  private :: renormalize_smb_accumulate_sums_g
+  private :: renormalize_smb_do_renormalization
 
   ! -----------------
   ! lnd -> glc
@@ -96,10 +105,15 @@ module med_phases_prep_glc_mod
   type(ESMF_Field)               :: field_frac_l_ec
 
   character(len=*), parameter    :: qice_fieldname       = 'Flgl_qice' ! Name of flux field giving surface mass balance
+  character(len=*), parameter    :: qice_elev_fieldname  = 'Flgl_qice_elev' ! Name of flux field giving surface mass balance, separated by elevation class
+  character(len=*), parameter    :: qice_wtracers_fieldname = qice_fieldname//WTRACERS_SUFFIX
+  character(len=*), parameter    :: qice_elev_wtracers_fieldname = qice_elev_fieldname//WTRACERS_SUFFIX
   character(len=*), parameter    :: Sg_frac_fieldname    = 'Sg_ice_covered'
   character(len=*), parameter    :: Sg_topo_fieldname    = 'Sg_topo'
   character(len=*), parameter    :: Sg_icemask_fieldname = 'Sg_icemask'
   integer                        :: ungriddedCount ! this equals the number of elevation classes + 1 (for bare land)
+  logical                        :: has_wtracers ! true if this simulation has water tracers
+  integer                        :: num_wtracers ! number of water tracers in this simulation
 
   ! -----------------
   ! ocn -> glc
@@ -157,6 +171,14 @@ contains
     ! allocate module variables
     allocate(toglc_frlnd(is_local%wrap%num_icesheets))
 
+    ! Check whether this simulation has water tracers
+    has_wtracers = wtracers_present()
+    if (has_wtracers) then
+       num_wtracers = wtracers_get_num_tracers()
+    else
+       num_wtracers = 0
+    end if
+
     ! -------------------------------
     ! If will accumulate lnd2glc input on land grid
     ! -------------------------------
@@ -187,6 +209,18 @@ contains
           call ESMF_LogWrite(trim(subname)//' adding field '//trim(fldnames_fr_lnd(n))//' to FBLndAccum_l', &
                ESMF_LOGMSG_INFO)
        end do
+       if (has_wtracers) then
+          lfield = ESMF_FieldCreate(mesh_l, ESMF_TYPEKIND_R8, name=qice_elev_wtracers_fieldname, &
+               meshloc=ESMF_MESHLOC_ELEMENT, &
+               ! Note the assumption of dimension ordering here: [elev, wtracer, gridcell]
+               ungriddedLbound=(/1,1/), ungriddedUbound=(/ungriddedCount, num_wtracers/), gridToFieldMap=(/3/), &
+               rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_FieldBundleAdd(FBlndAccum2glc_l, (/lfield/), rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+          call ESMF_LogWrite(trim(subname)//' adding field '//qice_elev_wtracers_fieldname//' to FBLndAccum_l', &
+               ESMF_LOGMSG_INFO)
+       end if
        call fldbun_reset(FBlndAccum2glc_l, value=0.0_r8, rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
@@ -215,6 +249,16 @@ contains
              call ESMF_FieldBundleAdd(toglc_frlnd(ns)%FBlndAccum2glc_g, (/lfield/), rc=rc)
              if (chkerr(rc,__LINE__,u_FILE_u)) return
           end do
+          if (has_wtracers) then
+             lfield = ESMF_FieldCreate(toglc_frlnd(ns)%mesh_g, ESMF_TYPEKIND_R8, name=qice_elev_wtracers_fieldname, &
+                  meshloc=ESMF_MESHLOC_ELEMENT, &
+                  ! Note the assumption of dimension ordering here: [elev, wtracer, gridcell]
+                  ungriddedLbound=(/1,1/), ungriddedUbound=(/ungriddedCount, num_wtracers/), gridToFieldMap=(/3/), &
+                  rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+             call ESMF_FieldBundleAdd(toglc_frlnd(ns)%FBlndAccum2glc_g, (/lfield/), rc=rc)
+             if (chkerr(rc,__LINE__,u_FILE_u)) return
+          end if
           call fldbun_reset(toglc_frlnd(ns)%FBlndAccum2glc_g, value=0.0_r8, rc=rc)
           if (chkerr(rc,__LINE__,u_FILE_u)) return
 
@@ -375,9 +419,6 @@ contains
 
     ! local variables
     type(InternalState) :: is_local
-    integer             :: i,n
-    real(r8), pointer   :: data2d_in(:,:)
-    real(r8), pointer   :: data2d_out(:,:)
     character(len=*),parameter :: subname=' (med_phases_prep_glc_accum) '
     !---------------------------------------
 
@@ -394,15 +435,8 @@ contains
     if (chkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Accumulate fields from land on land mesh that will be sent to glc
-    do n = 1, size(fldnames_fr_lnd)
-       call fldbun_getdata2d(is_local%wrap%FBImp(complnd,complnd), fldnames_fr_lnd(n), data2d_in, rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       call fldbun_getdata2d(FBlndAccum2glc_l, fldnames_fr_lnd(n), data2d_out, rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-       do i = 1,size(data2d_out, dim=2)
-          data2d_out(:,i) = data2d_out(:,i) + data2d_in(:,i)
-       end do
-    end do
+    call fldbun_accum(FBout=FBlndAccum2glc_l, FBin=is_local%wrap%FBImp(complnd,complnd), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
     lndAccum2glc_cnt = lndAccum2glc_cnt + 1
     if (dbug_flag > 1) then
        call fldbun_diagnose(FBlndAccum2glc_l, string=trim(subname)// ' FBlndAccum2glc_l ',  rc=rc)
@@ -622,22 +656,16 @@ contains
     if (do_avg) then
 
        ! Always average import from accumulated land import data
-       do n = 1, size(fldnames_fr_lnd)
-          if (fldchk(FBlndAccum2glc_l, fldnames_fr_lnd(n), rc=rc)) then
-             call fldbun_getdata2d(FBlndAccum2glc_l, fldnames_fr_lnd(n), data2d, rc)
-             if (chkerr(rc,__LINE__,u_FILE_u)) return
-             if (lndAccum2glc_cnt > 0) then
-                ! If accumulation count is greater than 0, do the averaging
-                data2d(:,:) = data2d(:,:) / real(lndAccum2glc_cnt, R8)
-             else
-                ! If accumulation count is 0, then simply set the averaged field bundle values from the land
-                ! to the import field bundle values
-                call fldbun_getdata2d(is_local%wrap%FBImp(complnd,complnd), fldnames_fr_lnd(n), data2d_import, rc)
-                if (chkerr(rc,__LINE__,u_FILE_u)) return
-                data2d(:,:) = data2d_import(:,:)
-             end if
-          end if
-       end do
+       if (lndAccum2glc_cnt > 0) then
+          ! If accumulation count is greater than 0, do the averaging
+          call fldbun_average(FB=FBlndAccum2glc_l, count=lndAccum2glc_cnt, rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       else
+          ! If accumulation count is 0, then simply set the averaged field bundle values from the land
+          ! to the import field bundle values
+          call fldbun_copy(FBout=FBlndAccum2glc_l, FBin=is_local%wrap%FBImp(complnd,complnd), rc=rc)
+          if (chkerr(rc,__LINE__,u_FILE_u)) return
+       end if
 
        if (is_local%wrap%ocn2glc_coupling) then
           ! Average import from accumulated ocn import data
@@ -730,6 +758,13 @@ contains
        end do
     end if
 
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    do ns = 1,is_local%wrap%num_icesheets
+       call med_methods_FB_check_wtracers(is_local%wrap%FBExp(compglc(ns)), rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+    end do
+
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
     endif
@@ -766,8 +801,10 @@ contains
     real(r8), pointer   :: topoglc_g(:)           ! ice topographic height on the glc grid extracted from glc import
     real(r8), pointer   :: ice_covered_g(:)       ! if points on the glc grid is ice-covered (1) or ice-free (0)
     integer , pointer   :: elevclass_g(:)         ! elevation classes glc grid
-    real(r8), pointer   :: dataexp_g(:)           ! pointer into
+    real(r8), pointer   :: dataexp1d_g(:)
+    real(r8), pointer   :: dataexp2d_g(:,:)
     real(r8), pointer   :: dataptr2d(:,:)
+    real(r8), pointer   :: dataptr3d(:,:,:)
     real(r8)            :: elev_l, elev_u         ! lower and upper elevations in interpolation range
     real(r8)            :: d_elev                 ! elev_u - elev_l
     integer             :: nfld, ec
@@ -775,7 +812,7 @@ contains
     integer,  allocatable :: index_upper(:)   ! upper EC index for vertical interpolation, per glc gridcell
     real(r8), allocatable :: weight_lower(:)  ! weight for lower EC, per glc gridcell
     real(r8), allocatable :: weight_upper(:)  ! weight for upper EC, per glc gridcell
-    integer             :: n,lsize_g,ns
+    integer             :: n,lsize_g,ns,t
     type(ESMF_Field)    :: field_lfrac_l
     integer             :: fieldCount
     character(len=3)    :: cnum
@@ -790,15 +827,9 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! ------------------------------------------------------------------------
-    ! Map the accumulate land field from the land grid (in multiple elevation classes)
+    ! Map the accumulated land field from the land grid (in multiple elevation classes)
     ! to the glc grid (in multiple elevation classes) using bilinear interpolation
     ! ------------------------------------------------------------------------
-
-    ! Initialize accumulated field bundle on the glc grid to zero before doing the mapping
-    do ns = 1,is_local%wrap%num_icesheets
-       call fldbun_reset(toglc_frlnd(ns)%FBlndAccum2glc_g, value=0.0_r8, rc=rc)
-       if (chkerr(rc,__LINE__,u_FILE_u)) return
-    end do
 
     ! TODO(wjs, 2015-01-20) This implies that we pass data to CISM even in places that
     ! CISM says is ocean (so CISM will ignore the incoming value). This differs from the
@@ -818,12 +849,10 @@ contains
     call ESMF_FieldBundleGet(is_local%wrap%FBFrac(complnd), fieldName=map_fracname_lnd2glc, field=field_lfrac_l, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    ! map accumlated land fields to each ice sheet (normalize by the land fraction in the mapping)
+    ! map accumulated land fields to each ice sheet (normalize by the land fraction in the mapping)
     do ns = 1,is_local%wrap%num_icesheets
        call fldbun_reset(toglc_frlnd(ns)%FBlndAccum2glc_g, value=0.0_r8, rc=rc)
        if (chkErr(rc,__LINE__,u_FILE_u)) return
-    end do
-    do ns = 1,is_local%wrap%num_icesheets
        call ESMF_FieldBundleGet(toglc_frlnd(ns)%FBlndAccum2glc_g, fieldlist=fieldlist_glc, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
        do nfld = 1,fieldcount
@@ -953,26 +982,60 @@ contains
           if (chkErr(rc,__LINE__,u_FILE_u)) return
 
           ! Get a pointer to the data for the field that will be sent to glc (without elevation classes)
-          call fldbun_getdata1d(is_local%wrap%FBExp(compglc(ns)), fldnames_to_glc(nfld), dataexp_g, rc)
+          call fldbun_getdata1d(is_local%wrap%FBExp(compglc(ns)), fldnames_to_glc(nfld), dataexp1d_g, rc)
           if (chkErr(rc,__LINE__,u_FILE_u)) return
 
           ! Apply pre-computed vertical interpolation indices and weights
           do n = 1, lsize_g
              if (elevclass_g(n) /= 0) then
                 ! ice-covered cells: vertically interpolate between bounding ECs
-                dataexp_g(n) = dataptr2d(index_lower(n), n) * weight_lower(n) &
-                             + dataptr2d(index_upper(n), n) * weight_upper(n)
+                dataexp1d_g(n) = dataptr2d(index_lower(n), n) * weight_lower(n) &
+                               + dataptr2d(index_upper(n), n) * weight_upper(n)
              else
                 ! non ice-covered cells: use bare land value (EC index 1)
-                dataexp_g(n) = dataptr2d(1, n)
+                dataexp1d_g(n) = dataptr2d(1, n)
              end if
-          end do  ! end of loop over land points
+          end do
 
        end do ! end loop over fields (nflds)
 
        ! ------------------------------------------------------------------------
-       ! Renormalize surface mass balance (smb, here named dataexp_g) so that the global
-       ! integral on the glc grid is equal to the global integral on the land grid.
+       ! Now do an equivalent vertical interpolation for the qice water tracer field. This
+       ! needs to be handled separately from the above loop because there is an extra
+       ! dimension in this field.
+       ! ------------------------------------------------------------------------
+
+       if (has_wtracers) then
+
+          ! Get a pointer to the land data in multiple elevation classes on the glc grid
+          call fldbun_getdata3d(toglc_frlnd(ns)%FBlndAccum2glc_g, qice_elev_wtracers_fieldname, dataptr3d, rc)
+          if (chkErr(rc,__LINE__,u_FILE_u)) return
+
+          ! Get a pointer to the data for the field that will be sent to glc (without elevation classes)
+          call fldbun_getdata2d(is_local%wrap%FBExp(compglc(ns)), qice_wtracers_fieldname, dataexp2d_g, rc)
+          if (chkErr(rc,__LINE__,u_FILE_u)) return
+
+          ! Apply pre-computed vertical interpolation indices and weights
+          do n = 1, lsize_g
+             if (elevclass_g(n) /= 0) then
+                ! ice-covered cells: vertically interpolate between bounding ECs
+                do t = 1, num_wtracers
+                   dataexp2d_g(t, n) = dataptr3d(index_lower(n), t, n) * weight_lower(n) &
+                                     + dataptr3d(index_upper(n), t, n) * weight_upper(n)
+                end do
+             else
+                ! non ice-covered cells: use bare land value (EC index 1)
+                do t = 1, num_wtracers
+                   dataexp2d_g(t, n) = dataptr3d(1, t, n)
+                end do
+             end if
+          end do
+
+       end if
+
+       ! ------------------------------------------------------------------------
+       ! Renormalize surface mass balance (smb) so that the global integral on the glc
+       ! grid is equal to the global integral on the land grid.
        ! ------------------------------------------------------------------------
 
        ! No longer need to make a preemptive adjustment to qice_g to account for area differences
@@ -1062,7 +1125,9 @@ contains
     type(InternalState) :: is_local
     type(ESMF_VM)       :: vm
     real(r8) , pointer  :: qice_g(:)       ! SMB (Flgl_qice) on glc grid without elev classes
-    real(r8) , pointer  :: qice_l_ec(:,:)  ! SMB (Flgl_qice) on land grid with elev classes
+    real(r8) , pointer  :: qice_l_ec(:,:)  ! SMB (Flgl_qice_elev) on land grid with elev classes
+    real(r8) , pointer  :: qice_g_wtracers(:,:) ! SMB water tracers (Flgl_qice_wtracers) on glc grid without elev classes
+    real(r8) , pointer  :: qice_l_ec_wtracers(:,:,:) ! SMB water tracers (Flgl_qice_elev_wtracers) on land grid with elev classes
     real(r8) , pointer  :: topo_g(:)       ! ice topographic height on the glc grid cell
     real(r8) , pointer  :: frac_g(:)       ! total ice fraction in each glc cell
     real(r8) , pointer  :: frac_g_ec(:,:)  ! total ice fraction in each glc cell
@@ -1071,19 +1136,17 @@ contains
     real(r8) , pointer  :: icemask_l(:)    ! icemask on land grid
     real(r8) , pointer  :: lndfrac(:)      ! land fraction on land grid
     real(r8) , pointer  :: dataptr1d(:)    ! temporary 1d pointer
-    integer             :: ec              ! loop index over elevation classes
-    integer             :: n
+    integer             :: n, t
 
     ! local and global sums of accumulation and ablation; used to compute renormalization factors
-    real(r8) :: local_accum_lnd(1), global_accum_lnd(1)
-    real(r8) :: local_accum_glc(1), global_accum_glc(1)
-    real(r8) :: local_ablat_lnd(1), global_ablat_lnd(1)
-    real(r8) :: local_ablat_glc(1), global_ablat_glc(1)
+    ! the first element of each of these is for bulk water; the remaining elements are for water tracers
+    real(r8) :: local_accum_lnd(1+num_wtracers), global_accum_lnd(1+num_wtracers)
+    real(r8) :: local_accum_glc(1+num_wtracers), global_accum_glc(1+num_wtracers)
+    real(r8) :: local_ablat_lnd(1+num_wtracers), global_ablat_lnd(1+num_wtracers)
+    real(r8) :: local_ablat_glc(1+num_wtracers), global_ablat_glc(1+num_wtracers)
 
-    ! renormalization factors (should be close to 1, e.g. in range 0.95 to 1.05)
-    real(r8) :: accum_renorm_factor ! ratio between global accumulation on the two grids
-    real(r8) :: ablat_renorm_factor ! ratio between global ablation on the two grids
-    real(r8) :: effective_area      ! grid cell area multiplied by min(lndfrac,icemask_l).
+    ! areas
+    real(r8), allocatable :: effective_area_l(:) ! effective areas on the land grid: grid cell area multiplied by min(lndfrac,icemask_l).
     real(r8), pointer :: area_g(:)  ! areas on glc grid
     character(len=*), parameter  :: subname=' (renormalize_smb) '
     !---------------------------------------------------------------
@@ -1167,83 +1230,208 @@ contains
     call fldbun_getdata1d(is_local%wrap%FBFrac(complnd), map_fracname_lnd2glc, lndfrac, rc)
     if (chkErr(rc,__LINE__,u_FILE_u)) return
 
-    ! get qice_l_ec
-    call fldbun_getdata2d(FBlndAccum2glc_l, trim(qice_fieldname)//'_elev', qice_l_ec, rc)
-    if (chkErr(rc,__LINE__,u_FILE_u)) return
-
-    local_accum_lnd(1) = 0.0_r8
-    local_ablat_lnd(1) = 0.0_r8
+    allocate(effective_area_l(size(lndfrac)))
     do n = 1, size(lndfrac)
-       ! Calculate effective area for sum -  need the mapped icemask_l
-       effective_area = min(lndfrac(n), icemask_l(n)) * is_local%wrap%mesh_info(complnd)%areas(n)
-       if (effective_area > 0.0_r8) then
-          do ec = 1, ungriddedCount
-             if (qice_l_ec(ec,n) >= 0.0_r8) then
-                local_accum_lnd(1) = local_accum_lnd(1) + effective_area * frac_l_ec(ec,n) * qice_l_ec(ec,n)
-             else
-                local_ablat_lnd(1) = local_ablat_lnd(1) + effective_area * frac_l_ec(ec,n) * qice_l_ec(ec,n)
-             endif
-          end do ! ec
-       end if ! if landmaks > 0
-    enddo  ! n
+       effective_area_l(n) = min(lndfrac(n), icemask_l(n)) * is_local%wrap%mesh_info(complnd)%areas(n)
+    end do
 
+    ! determine accumulation and ablation sums for qice on the land grid
+    call fldbun_getdata2d(FBlndAccum2glc_l, trim(qice_elev_fieldname), qice_l_ec, rc)
+    if (chkErr(rc,__LINE__,u_FILE_u)) return
+    call renormalize_smb_accumulate_sums_l(qice_l_ec, effective_area_l, frac_l_ec, &
+         local_accum_lnd(1), local_ablat_lnd(1))
+
+    ! and, similarly, determine accumulation and ablation sums for qice water tracers on the land grid
+    if (has_wtracers) then
+       call fldbun_getdata3d(FBlndAccum2glc_l, trim(qice_elev_wtracers_fieldname), qice_l_ec_wtracers, rc)
+       if (chkErr(rc,__LINE__,u_FILE_u)) return
+       do t = 1, num_wtracers
+          call renormalize_smb_accumulate_sums_l(qice_l_ec_wtracers(:,t,:), effective_area_l, frac_l_ec, &
+               local_accum_lnd(1+t), local_ablat_lnd(1+t))
+       end do
+    end if
+
+    deallocate(effective_area_l)
+
+    ! determine global accum/ablat on the land grid
     call ESMF_GridCompGet(gcomp, vm=vm, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMAllreduce(vm, senddata=local_accum_lnd, recvdata=global_accum_lnd, count=1, &
+    call ESMF_VMAllreduce(vm, senddata=local_accum_lnd, recvdata=global_accum_lnd, count=1+num_wtracers, &
          reduceflag=ESMF_REDUCE_SUM, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_VMAllreduce(vm, senddata=local_ablat_lnd, recvdata=global_ablat_lnd, count=1, &
+    call ESMF_VMAllreduce(vm, senddata=local_ablat_lnd, recvdata=global_ablat_lnd, count=1+num_wtracers, &
          reduceflag=ESMF_REDUCE_SUM, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (maintask) then
-       write(logunit,'(a,d21.10)') trim(subname)//'global_accum_lnd = ', global_accum_lnd
-       write(logunit,'(a,d21.10)') trim(subname)//'global_ablat_lnd = ', global_ablat_lnd
+       write(logunit,'(a,d21.10)') trim(subname)//'global_accum_lnd = ', global_accum_lnd(1)
+       write(logunit,'(a,d21.10)') trim(subname)//'global_ablat_lnd = ', global_ablat_lnd(1)
+       do t = 1, num_wtracers
+          write(logunit,'(a,i0,a,d21.10)') trim(subname)//'tracer #', t, &
+               ': global_accum_lnd = ', global_accum_lnd(1+t)
+          write(logunit,'(a,i0,a,d21.10)') trim(subname)//'tracer #', t, &
+               ': global_ablat_lnd = ', global_ablat_lnd(1+t)
+       end do
     endif
 
     !---------------------------------------
     ! Sum qice_g over local glc grid cells.
     !---------------------------------------
 
-    ! determine qice_g
-    call fldbun_getdata1d(is_local%wrap%FBExp(compglc(ns)), qice_fieldname, qice_g, rc)
-    if (chkerr(rc,__LINE__,u_FILE_u)) return
-
     ! get areas internal to glc grid
     call fldbun_getdata1d(is_local%wrap%FBImp(compglc(ns),compglc(ns)), 'Sg_area', area_g, rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
-    local_accum_glc(1) = 0.0_r8
-    local_ablat_glc(1) = 0.0_r8
-    do n = 1, size(qice_g)
-       if (qice_g(n) >= 0.0_r8) then
-          local_accum_glc(1) = local_accum_glc(1) + icemask_g(n) * area_g(n) * qice_g(n)
-       else
-          local_ablat_glc(1) = local_ablat_glc(1) + icemask_g(n) * area_g(n) * qice_g(n)
-       endif
-    enddo  ! n
-    call ESMF_VMAllreduce(vm, senddata=local_accum_glc, recvdata=global_accum_glc, count=1, &
+    ! determine accumulation and ablation sums for qice on the glc grid
+    call fldbun_getdata1d(is_local%wrap%FBExp(compglc(ns)), qice_fieldname, qice_g, rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
+    call renormalize_smb_accumulate_sums_g(qice_g, icemask_g, area_g, &
+         local_accum_glc(1), local_ablat_glc(1))
+
+    ! and, similarly, determine accumulation and ablation sums for qice water tracers on the glc grid
+    if (has_wtracers) then
+       call fldbun_getdata2d(is_local%wrap%FBExp(compglc(ns)), qice_wtracers_fieldname, qice_g_wtracers, rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+       do t = 1, num_wtracers
+          call renormalize_smb_accumulate_sums_g(qice_g_wtracers(t,:), icemask_g, area_g, &
+               local_accum_glc(1+t), local_ablat_glc(1+t))
+       end do
+    end if
+
+    ! determine global accum/ablat on the glc grid
+    call ESMF_VMAllreduce(vm, senddata=local_accum_glc, recvdata=global_accum_glc, count=1+num_wtracers, &
          reduceflag=ESMF_REDUCE_SUM, rc=rc)
-    call ESMF_VMAllreduce(vm, senddata=local_ablat_glc, recvdata=global_ablat_glc, count=1, &
+    call ESMF_VMAllreduce(vm, senddata=local_ablat_glc, recvdata=global_ablat_glc, count=1+num_wtracers, &
          reduceflag=ESMF_REDUCE_SUM, rc=rc)
     if (maintask) then
-       write(logunit,'(a,d21.10)') trim(subname)//'global_accum_glc = ', global_accum_glc
-       write(logunit,'(a,d21.10)') trim(subname)//'global_ablat_glc = ', global_ablat_glc
+       write(logunit,'(a,d21.10)') trim(subname)//'global_accum_glc = ', global_accum_glc(1)
+       write(logunit,'(a,d21.10)') trim(subname)//'global_ablat_glc = ', global_ablat_glc(1)
+       do t = 1, num_wtracers
+          write(logunit,'(a,i0,a,d21.10)') trim(subname)//'tracer #', t, &
+               ': global_accum_glc = ', global_accum_glc(1+t)
+          write(logunit,'(a,i0,a,d21.10)') trim(subname)//'tracer #', t, &
+               ': global_ablat_glc = ', global_ablat_glc(1+t)
+       end do
     endif
 
-    ! Renormalize
-    if (global_accum_glc(1) > 0.0_r8) then
-       accum_renorm_factor = global_accum_lnd(1) / global_accum_glc(1)
+    ! finally, do the actual renormalization
+    call renormalize_smb_do_renormalization(global_accum_lnd(1), global_ablat_lnd(1), &
+         global_accum_glc(1), global_ablat_glc(1), subname, qice_g)
+    do t = 1, num_wtracers
+       call renormalize_smb_do_renormalization(global_accum_lnd(1+t), global_ablat_lnd(1+t), &
+            global_accum_glc(1+t), global_ablat_glc(1+t), subname, qice_g_wtracers(t,:), &
+            tracer_num=t)
+    end do
+
+    call t_stopf('MED:'//subname)
+
+  end subroutine med_phases_prep_glc_renormalize_smb
+
+  !================================================================================================
+  subroutine renormalize_smb_accumulate_sums_l(qice_l_ec, effective_area_l, frac_l_ec, &
+       accum_l, ablat_l)
+
+    ! Compute local accumulation and ablation sums on land grid
+
+    ! input/output variables
+    real(r8), intent(in)  :: qice_l_ec(:,:)
+    real(r8), intent(in)  :: effective_area_l(:)
+    real(r8), intent(in)  :: frac_l_ec(:,:)
+    real(r8), intent(out) :: accum_l
+    real(r8), intent(out) :: ablat_l
+
+    ! local variables
+    integer :: n, ec
+    !---------------------------------------------------------------
+
+    accum_l = 0.0_r8
+    ablat_l = 0.0_r8
+    do n = 1, size(effective_area_l)
+       if (effective_area_l(n) > 0.0_r8) then
+          do ec = 1, ungriddedCount
+             if (qice_l_ec(ec,n) >= 0.0_r8) then
+                accum_l = accum_l + effective_area_l(n) * frac_l_ec(ec,n) * qice_l_ec(ec,n)
+             else
+                ablat_l = ablat_l + effective_area_l(n) * frac_l_ec(ec,n) * qice_l_ec(ec,n)
+             end if
+          end do
+       end if
+    end do
+
+  end subroutine renormalize_smb_accumulate_sums_l
+
+  !================================================================================================
+  subroutine renormalize_smb_accumulate_sums_g(qice_g, icemask_g, area_g, &
+       accum_g, ablat_g)
+
+    ! Compute local accumulation and ablation sums on glc grid
+
+    ! input/output variables
+    real(r8), intent(in)  :: qice_g(:)
+    real(r8), intent(in)  :: icemask_g(:)
+    real(r8), intent(in)  :: area_g(:)
+    real(r8), intent(out) :: accum_g
+    real(r8), intent(out) :: ablat_g
+
+    ! local variables
+    integer :: n
+    !---------------------------------------------------------------
+
+    accum_g = 0.0_r8
+    ablat_g = 0.0_r8
+    do n = 1, size(qice_g)
+       if (qice_g(n) >= 0.0_r8) then
+          accum_g = accum_g + icemask_g(n) * area_g(n) * qice_g(n)
+       else
+          ablat_g = ablat_g + icemask_g(n) * area_g(n) * qice_g(n)
+       end if
+    end do
+
+  end subroutine renormalize_smb_accumulate_sums_g
+
+  !================================================================================================
+  subroutine renormalize_smb_do_renormalization(global_accum_lnd, global_ablat_lnd, &
+       global_accum_glc, global_ablat_glc, caller_subname, qice_g, tracer_num)
+
+    ! Perform renormalization of qice_g using global sums
+
+    ! input/output variables
+    real(r8), intent(in)    :: global_accum_lnd
+    real(r8), intent(in)    :: global_ablat_lnd
+    real(r8), intent(in)    :: global_accum_glc
+    real(r8), intent(in)    :: global_ablat_glc
+    character(len=*), intent(in) :: caller_subname ! for diagnostic output
+    real(r8), intent(inout) :: qice_g(:)
+    integer, intent(in), optional :: tracer_num ! for diagnostic output
+
+    ! local variables
+    integer :: n
+
+    ! renormalization factors (should be close to 1, e.g. in range 0.95 to 1.05)
+    real(r8) :: accum_renorm_factor ! ratio between global accumulation on the two grids
+    real(r8) :: ablat_renorm_factor ! ratio between global ablation on the two grids
+
+    !---------------------------------------------------------------
+
+    if (global_accum_glc > 0.0_r8) then
+       accum_renorm_factor = global_accum_lnd / global_accum_glc
     else
        accum_renorm_factor = 0.0_r8
     endif
-    if (global_ablat_glc(1) < 0.0_r8) then  ! negative by definition
-       ablat_renorm_factor = global_ablat_lnd(1) / global_ablat_glc(1)
+    if (global_ablat_glc < 0.0_r8) then  ! negative by definition
+       ablat_renorm_factor = global_ablat_lnd / global_ablat_glc
     else
        ablat_renorm_factor = 0.0_r8
     endif
     if (maintask) then
-       write(logunit,'(a,d21.10)') trim(subname)//'accum_renorm_factor = ', accum_renorm_factor
-       write(logunit,'(a,d21.10)') trim(subname)//'ablat_renorm_factor = ', ablat_renorm_factor
+       if (present(tracer_num)) then
+          write(logunit,'(a,i0,a,d21.10)') trim(caller_subname)//'tracer #', tracer_num, &
+               ': accum_renorm_factor = ', accum_renorm_factor
+          write(logunit,'(a,i0,a,d21.10)') trim(caller_subname)//'tracer #', tracer_num, &
+               ': ablat_renorm_factor = ', ablat_renorm_factor
+       else
+          write(logunit,'(a,d21.10)') trim(caller_subname)//'accum_renorm_factor = ', accum_renorm_factor
+          write(logunit,'(a,d21.10)') trim(caller_subname)//'ablat_renorm_factor = ', ablat_renorm_factor
+       endif
     endif
 
     do n = 1, size(qice_g)
@@ -1252,11 +1440,9 @@ contains
        else
           qice_g(n) = qice_g(n) * ablat_renorm_factor
        endif
-    enddo
+    end do
 
-    call t_stopf('MED:'//subname)
-
-  end subroutine med_phases_prep_glc_renormalize_smb
+  end subroutine renormalize_smb_do_renormalization
 
   !================================================================================================
   subroutine dynOcnMaskProc(dynamicMaskList, dynamicSrcMaskValue, dynamicDstMaskValue, rc)

--- a/mediator/med_phases_prep_ice_mod.F90
+++ b/mediator/med_phases_prep_ice_mod.F90
@@ -34,6 +34,7 @@ contains
     use med_methods_mod       , only : FB_diagnose  => med_methods_FB_diagnose
     use med_methods_mod       , only : FB_GetFldPtr => med_methods_FB_GetFldPtr
     use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
+    use med_methods_mod       , only : med_methods_FB_check_wtracers
     use med_constants_mod     , only : dbug_flag    => med_constants_dbug_flag
     use med_merge_mod         , only : med_merge_auto
     use med_internalstate_mod , only : InternalState, logunit, maintask
@@ -153,6 +154,11 @@ contains
     ! Check for nans in fields export to ice
     call FB_check_for_nans(is_local%wrap%FBExp(compice), maintask, logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBExp(compice), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_lnd_mod.F90
+++ b/mediator/med_phases_prep_lnd_mod.F90
@@ -30,6 +30,7 @@ contains
     use esmFlds               , only : med_fldList_GetFldListTo, med_fldList_type
     use med_methods_mod       , only : fldbun_diagnose  => med_methods_FB_diagnose
     use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
+    use med_methods_mod       , only : med_methods_FB_check_wtracers
     use med_utils_mod         , only : chkerr           => med_utils_ChkErr
     use med_constants_mod     , only : dbug_flag        => med_constants_dbug_flag
     use med_internalstate_mod , only : complnd, compatm
@@ -131,6 +132,11 @@ contains
     ! Check for nans in fields export to lnd
     call FB_check_for_nans(is_local%wrap%FBExp(complnd), maintask, logunit, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBExp(complnd), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) then
        call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -21,6 +21,7 @@ module med_phases_prep_ocn_mod
   use med_methods_mod       , only : FB_copy       => med_methods_FB_copy
   use med_methods_mod       , only : FB_reset      => med_methods_FB_reset
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_field_info_mod    , only : med_field_info_type, med_field_info_array_from_state
   use esmFlds               , only : med_fldList_GetfldListTo, med_fldlist_type
   use med_internalstate_mod , only : compocn, compatm, compice, coupling_mode
@@ -100,7 +101,9 @@ contains
 
     use ESMF                    , only : ESMF_GridComp, ESMF_FieldBundleGet
     use ESMF                    , only : ESMF_LogWrite, ESMF_LOGMSG_INFO, ESMF_SUCCESS
-    use med_constants_mod       , only : shr_const_cpsw, shr_const_cpfw, shr_const_cpice, shr_const_tkfrz, shr_const_pi
+    use med_constants_mod       , only : shr_const_cpsw, shr_const_tkfrz, shr_const_pi
+    use med_constants_mod       , only : shr_const_cpice
+    use med_constants_mod       , only : shr_const_cpfw
     use med_phases_prep_atm_mod , only : med_phases_prep_atm_enthalpy_correction
     use med_phases_prep_atm_mod , only : med_phases_prep_atm_enthalpy_runoff
 
@@ -256,9 +259,10 @@ contains
           hevap(n)  = (tocn(n) - shr_const_tkfrz) * min(evap(n), 0._r8)   * shr_const_cpsw
           hcond(n)  = max((tocn(n) - shr_const_tkfrz), 0._r8) * max(evap(n), 0._r8)  * shr_const_cpsw
           hrofl(n)  = max((tocn(n) - shr_const_tkfrz), 0._r8) * rofl(n)  * shr_const_cpsw
-          hrofi(n)  = min((tocn(n) - shr_const_tkfrz), 0._r8) * rofi(n)  * shr_const_cpsw
           hrofl_glc(n) = max((tocn(n) - shr_const_tkfrz), 0._r8) * rofl_glc(n)  * shr_const_cpsw
-          hrofi_glc(n) = min((tocn(n) - shr_const_tkfrz), 0._r8) * rofi_glc(n)  * shr_const_cpsw
+          ! −10 C is a reasonable bulk temperature assumption for iceberg/land-ice runoff
+          hrofi(n)  = -10._r8 * rofi(n)  * shr_const_cpice
+          hrofi_glc(n) = -10._r8 * rofi_glc(n)  * shr_const_cpice
        end do
        if (FB_fldchk(is_local%wrap%FBExp(compatm), 'Faxx_sen', rc=rc)) then
           ! Determine enthalpy correction factor that will be added to the sensible heat flux sent to the atm
@@ -474,6 +478,12 @@ contains
           call FB_check_for_nans(is_local%wrap%FBExp(compocn), maintask, logunit, rc=rc)
           if (ChkErr(rc,__LINE__,u_FILE_u)) return
        endif
+
+       ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+       ! this will return without doing anything)
+       call med_methods_FB_check_wtracers(is_local%wrap%FBExp(compocn), rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
+
        ! zero accumulator
        is_local%wrap%ExpAccumOcnCnt = 0
        call FB_reset(is_local%wrap%FBExpAccumOcn, value=czero, rc=rc)

--- a/mediator/med_phases_prep_rof_mod.F90
+++ b/mediator/med_phases_prep_rof_mod.F90
@@ -26,6 +26,7 @@ module med_phases_prep_rof_mod
   use med_methods_mod       , only : fldbun_fldChk    => med_methods_FB_FldChk
   use med_methods_mod       , only : field_getdata1d  => med_methods_Field_getdata1d
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_field_info_mod    , only : med_field_info_type
   use med_field_info_mod    , only : med_field_info_create_directly, med_field_info_create_from_field
   use med_field_info_mod    , only : med_field_info_esmf_fieldcreate
@@ -417,6 +418,11 @@ contains
             string=trim(subname)//' FBexp(comprof) ', rc=rc)
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     end if
+
+    ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+    ! this will return without doing anything)
+    call med_methods_FB_check_wtracers(is_local%wrap%FBExp(comprof), rc=rc)
+    if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     !---------------------------------------
     ! zero accumulator and FBAccum

--- a/mediator/med_phases_prep_wav_mod.F90
+++ b/mediator/med_phases_prep_wav_mod.F90
@@ -18,6 +18,7 @@ module med_phases_prep_wav_mod
   use med_methods_mod       , only : FB_copy       => med_methods_FB_copy
   use med_methods_mod       , only : FB_reset      => med_methods_FB_reset
   use med_methods_mod       , only : FB_check_for_nans => med_methods_FB_check_for_nans
+  use med_methods_mod       , only : med_methods_FB_check_wtracers
   use med_field_info_mod    , only : med_field_info_type, med_field_info_array_from_state
   use esmFlds               , only : med_fldList_GetfldListTo
   use med_internalstate_mod , only : compatm, compwav
@@ -213,6 +214,11 @@ contains
        ! Check for nans in fields export to wav
        call FB_check_for_nans(is_local%wrap%FBExp(compwav), maintask, logunit, rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       ! Check water tracers (if there are no water tracers or these checks aren't enabled,
+       ! this will return without doing anything)
+       call med_methods_FB_check_wtracers(is_local%wrap%FBExp(compwav), rc=rc)
+       if (chkerr(rc,__LINE__,u_FILE_u)) return
 
        ! zero accumulator
        is_local%wrap%ExpAccumWavCnt = 0

--- a/mediator/med_phases_restart_mod.F90
+++ b/mediator/med_phases_restart_mod.F90
@@ -348,7 +348,7 @@ contains
              call med_io_enddef(io_file)
           end if
 
-          tbnds = days_since
+          tbnds = (/days_since,days_since/)
           call ESMF_LogWrite(trim(subname)//": time "//trim(time_units), ESMF_LOGMSG_INFO)
           if (whead(m)) then
              call ESMF_ClockGet(clock, calendar=calendar, rc=rc)
@@ -356,7 +356,7 @@ contains
              call med_io_define_time(io_file, time_units, calendar, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           else
-             call med_io_write_time(io_file, days_since, tbnds=(/days_since,days_since/), nt=1, rc=rc)
+             call med_io_write_time(io_file, days_since, tbnds=tbnds, nt=1, rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
           end if
 

--- a/ufs/wtracers_mod.F90
+++ b/ufs/wtracers_mod.F90
@@ -8,12 +8,56 @@ module wtracers_mod
    ! the CESM_share library.
    !-----------------------------------------------------------------------------
 
+   use shr_kind_mod      , only : r8=>SHR_KIND_R8
+
    implicit none
    private
 
-   public :: wtracers_is_wtracer_field  ! return true if the given field name is a water tracer field
+   public :: wtracers_present             ! return true if there are water tracers in this simulation
+   public :: wtracers_get_num_tracers     ! get number of water tracers in this simulation
+   public :: wtracers_is_wtracer_field    ! return true if the given field name is a water tracer field
+   public :: wtracers_get_bulk_fieldname  ! return the name of the equivalent bulk field corresponding to a water tracer field
+   public :: wtracers_check_tracer_ratios ! check tracer ratios against expectations
+
+   interface wtracers_check_tracer_ratios
+      module procedure wtracers_check_tracer_ratios_1d
+      module procedure wtracers_check_tracer_ratios_2d
+   end interface wtracers_check_tracer_ratios
+
+   ! Suffix for water tracer field names
+   character(len=*), parameter, public :: WTRACERS_SUFFIX = "_wtracers"
 
 contains
+
+   !-----------------------------------------------------------------------
+   function wtracers_present()
+      !
+      ! !DESCRIPTION:
+      ! Return true if there are water tracers in this simulation
+      !
+      ! In this stub implementation, we always return false, since water tracers are not
+      ! implemented here.
+      !
+      ! !ARGUMENTS
+      logical :: wtracers_present  ! function result
+      !-----------------------------------------------------------------------
+      wtracers_present = .false.
+   end function wtracers_present
+
+   !-----------------------------------------------------------------------
+   function wtracers_get_num_tracers()
+      !
+      ! !DESCRIPTION:
+      ! Get number of water tracers in this simulation
+      !
+      ! In this stub implementation, we always return 0, since water tracers are not
+      ! implemented here.
+      !
+      ! !ARGUMENTS
+      integer :: wtracers_get_num_tracers  ! function result
+      !-----------------------------------------------------------------------
+      wtracers_get_num_tracers = 0
+   end function wtracers_get_num_tracers
 
    !-----------------------------------------------------------------------
    function wtracers_is_wtracer_field(fieldname)
@@ -30,5 +74,57 @@ contains
       !-----------------------------------------------------------------------
       wtracers_is_wtracer_field = .false.
    end function wtracers_is_wtracer_field
+
+   !-----------------------------------------------------------------------
+   subroutine wtracers_get_bulk_fieldname(fieldname, is_wtracer_field, bulk_fieldname)
+      !
+      ! !DESCRIPTION:
+      ! Return the name of the equivalent bulk field corresponding to a water tracer field
+      !
+      ! In this stub implementation, we always return false for is_wtracer_field, and set
+      ! bulk_fieldname equal to fieldname, since water tracers are not implemented here.
+      !
+      ! !ARGUMENTS
+      character(len=*), intent(in)  :: fieldname
+      logical         , intent(out) :: is_wtracer_field
+      character(len=*), intent(out) :: bulk_fieldname
+      !-----------------------------------------------------------------------
+      is_wtracer_field = .false.
+      bulk_fieldname = fieldname
+   end subroutine wtracers_get_bulk_fieldname
+
+   !-----------------------------------------------------------------------
+   subroutine wtracers_check_tracer_ratios_1d(tracers, bulk, name)
+      !
+      ! !DESCRIPTION:
+      ! Check tracer ratios (tracer/bulk) against expectations
+      !
+      ! In this stub implementation, we simply return without doing anything
+      !
+      ! !ARGUMENTS
+      real(r8), intent(in) :: tracers(:,:)  ! dimensioned [tracerNum, gridcell]
+      real(r8), intent(in) :: bulk(:)
+      character(len=*), intent(in) :: name  ! for diagnostic output
+      !-----------------------------------------------------------------------
+
+      ! Do nothing
+   end subroutine wtracers_check_tracer_ratios_1d
+
+   !-----------------------------------------------------------------------
+   subroutine wtracers_check_tracer_ratios_2d(tracers, bulk, name)
+      !
+      ! !DESCRIPTION:
+      ! Check tracer ratios (tracer/bulk) against expectations for 2-d bulk arrays
+      !
+      ! In this stub implementation, we simply return without doing anything
+      !
+      ! !ARGUMENTS
+      real(r8), intent(in) :: tracers(:,:,:)  ! dimensioned [ungriddedDim, tracerNum, gridcell]
+      real(r8), intent(in) :: bulk(:,:)       ! dimensioned [ungriddedDim, gridcell]
+      character(len=*), intent(in) :: name  ! for diagnostic output
+      !-----------------------------------------------------------------------
+
+      ! Do nothing
+   end subroutine wtracers_check_tracer_ratios_2d
 
 end module wtracers_mod


### PR DESCRIPTION
### Description of changes
Update to ESCOMP cmeps1.1.48 . 

### Specific notes
This is a necessary step before we make a PR back to ESCOM to merge all of the current NorESM changes back to ESCOMP.

Contributors other than yourself, if any:

CMEPS Issues Fixed:

Are changes expected to change answers? bfb

Any User Interface Changes (namelist or namelist defaults changes)? 

### Testing performed
- platform - olivia
- code - noresm3_0_beta18 share updated to share1.1.20_noresm_v0 and cmeps using this PR
- comparison - with noresm3_0_beta18
- tests:
  - [x] prealpha_noresm - all pass 
  - [x] aux_blom_noresm - all pass (other than expected fails)
  - [x] aux_cam_noresm - all pass except for  
     -  ERP_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.olivia_intel.cam-outfrq9s which now has a 0: cxil_map: write error in the case2run phase
     - ERP_D_Ln9.ne30pg3_ne30pg3_mtn14.NF1850.olivia_gnu.cam-outfrq9s_aero_history which is a gnu test but using Alok's modules which are known to be problematic for gnu
  

   